### PR TITLE
TSPS-349 fix: remove -SNAPSHOT suffix from tag

### DIFF
--- a/.github/workflows/bump-build-publish-cli.yml
+++ b/.github/workflows/bump-build-publish-cli.yml
@@ -59,7 +59,6 @@ jobs:
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: pyproject.toml
           VERSION_LINE_MATCH: "^version\\s*=\\s*\".*\""
-          VERSION_SUFFIX: SNAPSHOT
 
   build-and-publish:
     name: Build and publish Python client to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "terralab-cli"
-version = "0.0.1-SNAPSHOT"
+version = "0.0.1"
 description = "Command line interface for interacting with the Terra Scientific Pipelines Service, or Teaspoons."
 authors = ["Terra Scientific Services <teaspoons-developers@broadinstitute.org>"]
 readme = "README.md"


### PR DESCRIPTION
### Description 

Attempt to fix the new tag/version generation:
- don't add a SNAPSHOT suffix to the tag that's written as the new version in pyproject.toml
- fix current pyproject.toml that got written with that suffix from the previous run

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-349