### PR TITLE
TSPS-349 another fix attempt: request the new tag

### DIFF
--- a/.github/workflows/bump-build-publish-cli.yml
+++ b/.github/workflows/bump-build-publish-cli.yml
@@ -83,8 +83,9 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
 
-      - name: Report current terralab-cli version
+      - name: Pull latest version, report current terralab-cli version
         run: |
+          git pull
           poetry version
 
       - name: Build the CLI using poetry

--- a/.github/workflows/bump-build-publish-cli.yml
+++ b/.github/workflows/bump-build-publish-cli.yml
@@ -76,7 +76,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.tag-job.outputs.tag }}
-          fetch-depth: 0
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -86,12 +85,9 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
 
-      # - name: Pull newly tagged version, report current terralab-cli version
-      #   run: |
-      #     git fetch --all --tags --prune
-      #     git checkout tags/${{ needs.tag-job.outputs.tag }} -b main
-      #     poetry install
-      #     poetry version
+      - name: Report current terralab-cli version
+        run: |
+          poetry version
 
       - name: Build the CLI using poetry
         run: |

--- a/.github/workflows/bump-build-publish-cli.yml
+++ b/.github/workflows/bump-build-publish-cli.yml
@@ -113,6 +113,6 @@ jobs:
           status: failure
           channel: "#terra-tsps-alerts"
           username: "Bump, Build, and Publish Terralab CLI"
-          author_name: "test-python-cli"
+          author_name: "bump-build-publish-cli workflow"
           icon_emoji: ":triangular_ruler:"
           fields: job, commit

--- a/.github/workflows/bump-build-publish-cli.yml
+++ b/.github/workflows/bump-build-publish-cli.yml
@@ -26,6 +26,8 @@ jobs:
     needs: [ bump-check ]
     runs-on: ubuntu-latest
     if: needs.bump-check.outputs.is-bump == 'no'
+    outputs:
+      tag: ${{ steps.tag.outputs.new_tag }}
     steps:
       - name: Set part of semantic version to bump
         id: controls
@@ -73,6 +75,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ needs.tag-job.outputs.tag }}
           fetch-depth: 0
 
       - name: Set up Python 3.12
@@ -83,10 +86,12 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
 
-      - name: Pull latest version, report current terralab-cli version
-        run: |
-          git pull
-          poetry version
+      # - name: Pull newly tagged version, report current terralab-cli version
+      #   run: |
+      #     git fetch --all --tags --prune
+      #     git checkout tags/${{ needs.tag-job.outputs.tag }} -b main
+      #     poetry install
+      #     poetry version
 
       - name: Build the CLI using poetry
         run: |

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -51,7 +51,12 @@ jobs:
 
       - name: (TESTING) Pull latest version, report current terralab-cli version
         run: |
-          git pull
+          echo "version before getting tag"
+          poetry version
+          git fetch --all --tags --prune
+          git checkout tags/0.0.2 -b main
+          poetry install
+          echo "version after getting tag"
           poetry version
 
       - name: Run linter check (ruff)

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -54,7 +54,7 @@ jobs:
           echo "version before getting tag"
           poetry version
           git fetch --all --tags --prune
-          git checkout tags/0.0.2 -b main
+          git checkout tags/0.0.1 -b main
           poetry install
           echo "version after getting tag"
           poetry version

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -36,6 +36,8 @@ jobs:
     if: needs.bump-check.outputs.is-bump == 'no'
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: 0.0.1
       
       - name: Set up python
         uses: actions/setup-python@v5
@@ -51,13 +53,13 @@ jobs:
 
       - name: (TESTING) Pull latest version, report current terralab-cli version
         run: |
-          echo "version before getting tag"
+          # echo "version before getting tag"
           poetry version
-          git fetch --all --tags --prune
-          git checkout tags/0.0.1 -b main
-          poetry install
-          echo "version after getting tag"
-          poetry version
+          # git fetch --all --tags --prune
+          # git checkout tags/0.0.1 -b main
+          # poetry install
+          # echo "version after getting tag"
+          # poetry version
 
       - name: Run linter check (ruff)
         run: |

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -49,6 +49,11 @@ jobs:
         run: |
           poetry install
 
+      - name: (TESTING) Pull latest version, report current terralab-cli version
+        run: |
+          git pull
+          poetry version
+
       - name: Run linter check (ruff)
         run: |
           poetry run ruff check

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -36,8 +36,6 @@ jobs:
     if: needs.bump-check.outputs.is-bump == 'no'
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: 0.0.1
       
       - name: Set up python
         uses: actions/setup-python@v5
@@ -50,16 +48,6 @@ jobs:
       - name: Install the thick CLI
         run: |
           poetry install
-
-      - name: (TESTING) Pull latest version, report current terralab-cli version
-        run: |
-          # echo "version before getting tag"
-          poetry version
-          # git fetch --all --tags --prune
-          # git checkout tags/0.0.1 -b main
-          # poetry install
-          # echo "version after getting tag"
-          # poetry version
 
       - name: Run linter check (ruff)
         run: |

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -78,6 +78,6 @@ jobs:
           status: failure
           channel: "#terra-tsps-alerts"
           username: "Terralab CLI push to main branch"
-          author_name: "test-python-cli"
+          author_name: "test-cli workflow"
           icon_emoji: ":triangular_ruler:"
           fields: job, commit


### PR DESCRIPTION
### Description 

Previous attempt to get versioning working properly failed - it made the new tag but still built the older version (and errored out on push to pypi since that version already existed). 
- that PR: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/4
- failed run: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/actions/runs/11673105487/job/32503125043

This is another attempt to get the tag/build parts to work properly. Here we explicitly request the newly created tag that the bumper job has just created, before building the package and publishing to PyPi.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-349