### PR TITLE
TSPS-363 another fix attempt: use importlib to read config file

### DIFF
--- a/terralab/config.py
+++ b/terralab/config.py
@@ -1,6 +1,7 @@
 # config.py
 
 import logging
+from importlib import resources as impresources
 from pathlib import Path
 from oauth2_cli_auth import OAuth2ClientInfo
 from dotenv import dotenv_values
@@ -12,9 +13,15 @@ LOGGER = logging.getLogger(__name__)
 class CliConfig:
     """A class to hold configuration information for the CLI"""
 
-    def __init__(self, config_file="terralab/.terralab-cli-config"):
-        self.config = dotenv_values(config_file)
-        LOGGER.debug(f"Found config with values: {self.config}")
+    def __init__(self, config_file=".terralab-cli-config", package="terralab"):
+        # read values from the specified config file
+        try:
+            importable_config_file = impresources.files(package) / config_file
+            self.config = dotenv_values(importable_config_file)
+        except ModuleNotFoundError as e:
+            LOGGER.error(f"Failed to load config from {package}/{config_file}: {e}")
+            exit(1)
+        LOGGER.debug(f"Imported config with values: {self.config}")
 
         self.client_info = OAuth2ClientInfo.from_oidc_endpoint(
             self.config["OAUTH_OPENID_CONFIGURATION_URI"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ def test_config():
     mock_client_info = mock()
     when(config.OAuth2ClientInfo).from_oidc_endpoint(...).thenReturn(mock_client_info)
 
-    test_config = config.CliConfig("tests/.test.config")
+    test_config = config.CliConfig(config_file=".test.config", package="tests")
 
     assert test_config.config["TEASPOONS_API_URL"] == "not-real"
     assert test_config.config["SERVER_PORT"] == "12345"


### PR DESCRIPTION
### Description 

The package downloaded from PyPi still wasn't able to access the config file, though the config file was present in the package. Used the strategy described [here](https://stackoverflow.com/questions/6028000/how-to-read-a-static-file-from-inside-a-python-package) ([importlib](https://docs.python.org/3.11/library/importlib.resources.html)).

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-363