### PR TITLE
TSPS-373 fix token timeout

### DIFF
--- a/terralab/auth_helper.py
+++ b/terralab/auth_helper.py
@@ -142,6 +142,11 @@ def _exchange_code_for_response(
     :param grant_type: Type of grant request (default `authorization_code`, can also be `refresh_token`)
     :return: Response from OAuth2 endpoint
     """
+    # validate grant_type input. note this is not determined by user input.
+    if grant_type not in ["authorization_code", "refresh_token"]:
+        LOGGER.error(f"Authentication error: Unexpected grant_type {grant_type}")
+        exit(1)
+
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
         "Authorization": "Basic "

--- a/terralab/auth_helper.py
+++ b/terralab/auth_helper.py
@@ -162,13 +162,13 @@ def _validate_token(token: str) -> bool:
         # Note: We explicitly do not verify the signature of the token since that will be verified by the backend services.
         # This is just to ensure the token is not expired
         jwt.decode(token, options={"verify_signature": False, "verify_exp": True})
-        LOGGER.debug(f"Token {token[:10]} is not expired")
+        LOGGER.debug(f"Token {token[-5:]} is not expired")
         return True
     except jwt.ExpiredSignatureError:
-        LOGGER.debug(f"Token {token[:10]}  expired")
+        LOGGER.debug(f"Token {token[-5:]}  expired")
         return False
     except Exception as e:
-        LOGGER.error(f"Error validating token {token[:10]} : {e}")
+        LOGGER.error(f"Error validating token {token[-5:]} : {e}")
         return False
 
 

--- a/terralab/client.py
+++ b/terralab/client.py
@@ -6,10 +6,9 @@ from teaspoons_client import Configuration, ApiClient
 from terralab.config import CliConfig
 from terralab.auth_helper import (
     _load_local_token,
-    _validate_token,
     _save_local_token,
     get_tokens_with_browser_open,
-    refresh_tokens
+    refresh_tokens,
 )
 
 
@@ -43,15 +42,19 @@ class ClientWrapper:
         # first check if the access_token is present and valid
         if not (access_token):
             # next check the refresh token
-            if not (refresh_token): # and _validate_token(refresh_token)):
+            if not (refresh_token):  # and _validate_token(refresh_token)):
                 LOGGER.debug("No active access or refresh tokens found.")
                 LOGGER.info("No valid token found. Logging you in...")
-                access_token, refresh_token = get_tokens_with_browser_open(cli_config.client_info)
+                access_token, refresh_token = get_tokens_with_browser_open(
+                    cli_config.client_info
+                )
             else:
                 LOGGER.debug(f"Found refresh token {refresh_token[:10]}")
                 # found a refresh token, try to get a new access token
                 LOGGER.debug("Attempting to refresh tokens")
-                access_token, refresh_token = refresh_tokens(cli_config.client_info, refresh_token)
+                access_token, refresh_token = refresh_tokens(
+                    cli_config.client_info, refresh_token
+                )
             _save_local_token(cli_config.token_file, access_token)
             _save_local_token(cli_config.refresh_file, refresh_token)
 

--- a/terralab/client.py
+++ b/terralab/client.py
@@ -30,31 +30,37 @@ class ClientWrapper:
 
     def __enter__(self):
         cli_config = CliConfig()  # initialize the config from environment variables
-        # note that this load function only returns valid tokens
+        # note that this load function by default only returns valid tokens
         access_token = _load_local_token(cli_config.token_file)
         refresh_token = _load_local_token(cli_config.refresh_file, validate=False)
 
         if access_token:
-            LOGGER.debug(f"Found access token {access_token[:10]}")
+            LOGGER.debug(f"Found access token {access_token[-5:]}")
         if refresh_token:
-            LOGGER.debug(f"Found refresh token {refresh_token[:10]}")
+            LOGGER.debug(f"Found refresh token {refresh_token[-5:]}")
 
         # first check if the access_token is present and valid
         if not (access_token):
             # next check the refresh token
-            if not (refresh_token):  # and _validate_token(refresh_token)):
+            if refresh_token:
+                # found a refresh token, try to get a new access token
+                LOGGER.debug("Attempting to refresh tokens")
+                try:
+                    access_token, refresh_token = refresh_tokens(
+                        cli_config.client_info, refresh_token
+                    )
+                except Exception as e:
+                    LOGGER.debug(
+                        f"Error refreshing tokens ({e}), resorting to browser login"
+                    )
+                    refresh_token = None
+
+            if not (refresh_token):
                 LOGGER.debug("No active access or refresh tokens found.")
-                LOGGER.info("No valid token found. Logging you in...")
                 access_token, refresh_token = get_tokens_with_browser_open(
                     cli_config.client_info
                 )
-            else:
-                LOGGER.debug(f"Found refresh token {refresh_token[:10]}")
-                # found a refresh token, try to get a new access token
-                LOGGER.debug("Attempting to refresh tokens")
-                access_token, refresh_token = refresh_tokens(
-                    cli_config.client_info, refresh_token
-                )
+
             _save_local_token(cli_config.token_file, access_token)
             _save_local_token(cli_config.refresh_file, refresh_token)
 

--- a/terralab/client.py
+++ b/terralab/client.py
@@ -4,12 +4,7 @@ import logging
 
 from teaspoons_client import Configuration, ApiClient
 from terralab.config import CliConfig
-from terralab.auth_helper import (
-    _load_local_token,
-    _save_local_token,
-    get_tokens_with_browser_open,
-    refresh_tokens,
-)
+from terralab.auth_helper import get_or_refresh_access_token
 
 
 LOGGER = logging.getLogger(__name__)
@@ -30,39 +25,8 @@ class ClientWrapper:
 
     def __enter__(self):
         cli_config = CliConfig()  # initialize the config from environment variables
-        # note that this load function by default only returns valid tokens
-        access_token = _load_local_token(cli_config.token_file)
-        refresh_token = _load_local_token(cli_config.refresh_file, validate=False)
 
-        if access_token:
-            LOGGER.debug(f"Found access token {access_token[-5:]}")
-        if refresh_token:
-            LOGGER.debug(f"Found refresh token {refresh_token[-5:]}")
-
-        # first check if the access_token is present and valid
-        if not (access_token):
-            # next check the refresh token
-            if refresh_token:
-                # found a refresh token, try to get a new access token
-                LOGGER.debug("Attempting to refresh tokens")
-                try:
-                    access_token, refresh_token = refresh_tokens(
-                        cli_config.client_info, refresh_token
-                    )
-                except Exception as e:
-                    LOGGER.debug(
-                        f"Error refreshing tokens ({e}), resorting to browser login"
-                    )
-                    refresh_token = None
-
-            if not (refresh_token):
-                LOGGER.debug("No active access or refresh tokens found.")
-                access_token, refresh_token = get_tokens_with_browser_open(
-                    cli_config.client_info
-                )
-
-            _save_local_token(cli_config.token_file, access_token)
-            _save_local_token(cli_config.refresh_file, refresh_token)
+        access_token = get_or_refresh_access_token(cli_config)
 
         return _get_api_client(access_token, cli_config.config["TEASPOONS_API_URL"])
 

--- a/terralab/commands/pipeline_runs_commands.py
+++ b/terralab/commands/pipeline_runs_commands.py
@@ -1,4 +1,4 @@
-# commands/submit_commands.py
+# commands/pipeline_runs_commands.py
 
 import click
 import logging

--- a/terralab/config.py
+++ b/terralab/config.py
@@ -32,10 +32,10 @@ class CliConfig:
 
         self.server_port = int(self.config["SERVER_PORT"])
 
-        self.token_file = (
+        self.access_token_file = (
             f'{Path.home()}/{self.config["LOCAL_STORAGE_PATH"]}/access_token'
         )
 
-        self.refresh_file = (
+        self.refresh_token_file = (
             f'{Path.home()}/{self.config["LOCAL_STORAGE_PATH"]}/refresh_token'
         )

--- a/terralab/config.py
+++ b/terralab/config.py
@@ -26,7 +26,7 @@ class CliConfig:
         self.client_info = OAuth2ClientInfo.from_oidc_endpoint(
             self.config["OAUTH_OPENID_CONFIGURATION_URI"],
             client_id=self.config["OAUTH_CLIENT_ID"],
-            # scopes=[f"openid+email+profile+{self.config['OAUTH_CLIENT_ID']}"],
+            # including the offline_access scope is how we request a refresh token
             scopes=[f"offline_access+email+profile+{self.config['OAUTH_CLIENT_ID']}"],
         )
 

--- a/terralab/config.py
+++ b/terralab/config.py
@@ -26,11 +26,16 @@ class CliConfig:
         self.client_info = OAuth2ClientInfo.from_oidc_endpoint(
             self.config["OAUTH_OPENID_CONFIGURATION_URI"],
             client_id=self.config["OAUTH_CLIENT_ID"],
-            scopes=[f"openid+email+profile+{self.config['OAUTH_CLIENT_ID']}"],
+            # scopes=[f"openid+email+profile+{self.config['OAUTH_CLIENT_ID']}"],
+            scopes=[f"offline_access+email+profile+{self.config['OAUTH_CLIENT_ID']}"],
         )
 
         self.server_port = int(self.config["SERVER_PORT"])
 
         self.token_file = (
             f'{Path.home()}/{self.config["LOCAL_STORAGE_PATH"]}/access_token'
+        )
+
+        self.refresh_file = (
+            f'{Path.home()}/{self.config["LOCAL_STORAGE_PATH"]}/refresh_token'
         )

--- a/terralab/logic/auth_logic.py
+++ b/terralab/logic/auth_logic.py
@@ -2,27 +2,11 @@
 
 import logging
 from terralab.auth_helper import (
-    get_tokens_with_browser_open,
-    _validate_token,
-    _save_local_token,
-    _load_local_token,
     _clear_local_token,
 )
 from terralab.config import CliConfig
 
 LOGGER = logging.getLogger(__name__)
-
-
-def check_local_token_and_fetch_if_needed():
-    """Authenticate with Teaspoons via browser login to Terra b2c"""
-    cli_config = CliConfig()  # initialize the config from environment variables
-    token = _load_local_token(cli_config.token_file)
-    if token and _validate_token(token):
-        LOGGER.info("Already authenticated")
-        return
-    access_token, refresh_token = get_tokens_with_browser_open(cli_config.client_info)
-    _save_local_token(cli_config.token_file, access_token)
-    _save_local_token(cli_config.refresh_file, refresh_token)
 
 
 def clear_local_token():

--- a/terralab/logic/auth_logic.py
+++ b/terralab/logic/auth_logic.py
@@ -12,6 +12,6 @@ LOGGER = logging.getLogger(__name__)
 def clear_local_token():
     """Clear the local authentication token"""
     cli_config = CliConfig()  # initialize the config from environment variables
-    _clear_local_token(cli_config.token_file)
-    _clear_local_token(cli_config.refresh_file)
+    _clear_local_token(cli_config.access_token_file)
+    _clear_local_token(cli_config.refresh_token_file)
     LOGGER.info("Logged out")

--- a/terralab/logic/auth_logic.py
+++ b/terralab/logic/auth_logic.py
@@ -1,14 +1,33 @@
 # logic/auth_logic.py
 
 import logging
-from terralab.auth_helper import _clear_local_token
+from terralab.auth_helper import (
+    get_tokens_with_browser_open,
+    _validate_token,
+    _save_local_token,
+    _load_local_token,
+    _clear_local_token,
+)
 from terralab.config import CliConfig
 
 LOGGER = logging.getLogger(__name__)
+
+
+def check_local_token_and_fetch_if_needed():
+    """Authenticate with Teaspoons via browser login to Terra b2c"""
+    cli_config = CliConfig()  # initialize the config from environment variables
+    token = _load_local_token(cli_config.token_file)
+    if token and _validate_token(token):
+        LOGGER.info("Already authenticated")
+        return
+    access_token, refresh_token = get_tokens_with_browser_open(cli_config.client_info)
+    _save_local_token(cli_config.token_file, access_token)
+    _save_local_token(cli_config.refresh_file, refresh_token)
 
 
 def clear_local_token():
     """Clear the local authentication token"""
     cli_config = CliConfig()  # initialize the config from environment variables
     _clear_local_token(cli_config.token_file)
+    _clear_local_token(cli_config.refresh_file)
     LOGGER.info("Logged out")

--- a/terralab/logic/pipeline_runs_logic.py
+++ b/terralab/logic/pipeline_runs_logic.py
@@ -1,4 +1,4 @@
-# logic/submit_logic.py
+# logic/pipeline_runs_logic.py
 
 import logging
 import uuid

--- a/tests/commands/test_pipeline_runs_commands.py
+++ b/tests/commands/test_pipeline_runs_commands.py
@@ -1,4 +1,4 @@
-# tests/test_pipeline_runs_commands.py
+# tests/commands/test_pipeline_runs_commands.py
 
 import logging
 import uuid

--- a/tests/commands/test_pipeline_runs_commands.py
+++ b/tests/commands/test_pipeline_runs_commands.py
@@ -1,4 +1,4 @@
-# tests/test_submit_commands.py
+# tests/test_pipeline_runs_commands.py
 
 import logging
 import uuid

--- a/tests/logic/test_auth_logic.py
+++ b/tests/logic/test_auth_logic.py
@@ -8,7 +8,13 @@ from terralab.logic import auth_logic
 
 @pytest.fixture
 def mock_cli_config(unstub):
-    config = mock({"token_file": "mock_token_file", "client_info": "mock_client_info"})
+    config = mock(
+        {
+            "access_token_file": "mock_access_token_file",
+            "refresh_token_file": "mock_refresh_token_file",
+            "client_info": "mock_client_info",
+        }
+    )
     when(auth_logic).CliConfig(...).thenReturn(config)
     yield config
     unstub()
@@ -19,4 +25,5 @@ def test_clear_local_token(mock_cli_config, unstub):
 
     auth_logic.clear_local_token()
 
-    verify(auth_logic)._clear_local_token("mock_token_file")
+    verify(auth_logic)._clear_local_token("mock_access_token_file")
+    verify(auth_logic)._clear_local_token("mock_refresh_token_file")

--- a/tests/logic/test_pipeline_runs_logic.py
+++ b/tests/logic/test_pipeline_runs_logic.py
@@ -1,4 +1,4 @@
-# tests/logic/test_submit_logic.py
+# tests/logic/test_pipeline_runs_logic.py
 
 import pytest
 import uuid

--- a/tests/test_auth_helper.py
+++ b/tests/test_auth_helper.py
@@ -363,6 +363,19 @@ def test_exchange_code_for_response_refresh(capture_logs):
     assert "Token refresh successful" in capture_logs.text
 
 
+def test_exchange_code_for_response_bad_grant_type(capture_logs):
+    unexpected_grant_type = "what is this"
+    with pytest.raises(SystemExit):
+        auth_helper._exchange_code_for_response(
+            mock(), mock(), mock(), unexpected_grant_type
+        )
+
+    assert (
+        f"Authentication error: Unexpected grant_type {unexpected_grant_type}"
+        in capture_logs.text
+    )
+
+
 def test_validate_token_valid():
     access_token = "accesstoken"
 

--- a/tests/test_auth_helper.py
+++ b/tests/test_auth_helper.py
@@ -3,7 +3,7 @@
 import builtins
 import logging
 import pytest
-from mockito import when, mock, verify
+from mockito import when, mock, verify, times
 from jwt import ExpiredSignatureError
 from oauth2_cli_auth._timeout import TimeoutException
 
@@ -373,6 +373,23 @@ def test_load_local_token_invalid(mock_builtin_open):
     when(auth_helper)._validate_token(expected_access_token).thenReturn(False)
 
     assert auth_helper._load_local_token(mock_token_file) is None
+
+
+def test_load_local_token_do_not_validate(mock_builtin_open):
+    mock_token_file = mock()
+
+    expected_access_token = "accesstoken"
+
+    when(mock_builtin_open).read().thenReturn(expected_access_token)
+    when(auth_helper)._validate_token(...)
+
+    assert (
+        auth_helper._load_local_token(mock_token_file, validate=False)
+        == expected_access_token
+    )
+
+    # validate function should not have been called
+    verify(auth_helper, times(0))._validate_token()
 
 
 def test_load_local_token_file_not_found(mock_builtin_open):

--- a/tests/test_auth_helper.py
+++ b/tests/test_auth_helper.py
@@ -52,7 +52,7 @@ def test_get_access_token_with_browser_open_valid_code(mock_cli_config):
     when(mock_callback_server).wait_for_code().thenReturn(mock_code)
     when(auth_helper).exchange_code_for_access_token(...).thenReturn(mock_token)
 
-    token = auth_helper.get_access_token_with_browser_open(mock_client_info)
+    token = auth_helper.get_tokens_with_browser_open(mock_client_info)
 
     assert token == mock_token
 
@@ -83,7 +83,7 @@ def test_get_access_token_with_browser_open_no_code(mock_cli_config):
     when(mock_callback_server).wait_for_code().thenReturn(None)
 
     with pytest.raises(ValueError):
-        auth_helper.get_access_token_with_browser_open(mock_client_info)
+        auth_helper.get_tokens_with_browser_open(mock_client_info)
 
 
 def test_validate_token_valid():


### PR DESCRIPTION
### Description 

Add use of refresh tokens to avoid timeouts after long uploads.

Strategy:
- Check for a valid access token; if one exists, use it
- Otherwise, check for a refresh token; if one exists, attempt to get and save new tokens
- If refresh attempt fails or if no refresh token is found, prompt user to login via browser

Demo after logging in:
```
➜  rm ~/.terralab/access_token 
➜  terralab --debug pipelines list
Log level set to: DEBUG
Imported config with values: OrderedDict({'TEASPOONS_API_URL': 'https://tsps.dsde-dev.broadinstitute.org', 'SERVER_PORT': '10444', 'OAUTH_OPENID_CONFIGURATION_URI': 'https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin_dev/v2.0/.well-known/openid-configuration', 'OAUTH_CLIENT_ID': 'bbd07d43-01cb-4b69-8fd0-5746d9a5c9fe', 'LOCAL_STORAGE_PATH': '.terralab'})
No local token found to clean up
Attempting to refresh tokens
Token refresh successful
Starting new HTTPS connection (1): tsps.dsde-dev.broadinstitute.org:443
https://tsps.dsde-dev.broadinstitute.org:443 "GET /api/pipelines/v1 HTTP/11" 200 197
Found 1 available pipeline:
array_imputation
  Phase and impute genotypes using Beagle 5.4 with the AoU/AnVIL reference panel of 515,579 samples.

```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-373
