### PR TITLE
TSPS-382 get commands working without having to pass in pipeline name 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -541,13 +541,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pyjwt"
-version = "2.10.0"
+version = "2.10.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "PyJWT-2.10.0-py3-none-any.whl", hash = "sha256:543b77207db656de204372350926bed5a86201c4cbff159f623f79c7bb487a15"},
-    {file = "pyjwt-2.10.0.tar.gz", hash = "sha256:7628a7eb7938959ac1b26e819a1df0fd3259505627b575e4bad6d08f76db695c"},
+    {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
+    {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
 ]
 
 [package.extras]
@@ -558,13 +558,13 @@ tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pytest"
-version = "8.3.3"
+version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"},
-    {file = "pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181"},
+    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
+    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
 ]
 
 [package.dependencies]
@@ -710,23 +710,21 @@ files = [
 widechars = ["wcwidth"]
 
 [[package]]
-name = "teaspoons-client"
-version = "0.0.0"
+name = "terra-scientific-pipelines-service-api-client"
+version = "0.1.14"
 description = "Terra Scientific Pipelines Service"
 optional = false
-python-versions = "^3.7"
-files = []
-develop = false
+python-versions = "*"
+files = [
+    {file = "terra_scientific_pipelines_service_api_client-0.1.14-py3-none-any.whl", hash = "sha256:c0880c4e945d728c2f05faa8dac505b65202e423b14317fab29805666f35fbf0"},
+    {file = "terra_scientific_pipelines_service_api_client-0.1.14.tar.gz", hash = "sha256:4ce0a7889e0780cbc7f93470947597b2e705f93b4420dbdefc0c9a8ec5fe22a3"},
+]
 
 [package.dependencies]
 pydantic = ">=2"
 python-dateutil = ">=2.8.2"
 typing-extensions = ">=4.7.1"
-urllib3 = ">= 1.25.3"
-
-[package.source]
-type = "directory"
-url = "../terra-scientific-pipelines-service/python-client/generated"
+urllib3 = ">=1.25.3,<3.0.0"
 
 [[package]]
 name = "tqdm"
@@ -808,4 +806,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "3c5fcb275101430f75a9dff9902671675212103055d9c9f0ff8db355eda73d0e"
+content-hash = "077762c663b7a68f54e28c75c27d225a2e0674acab3c4400fc50b52ce75ee861"

--- a/poetry.lock
+++ b/poetry.lock
@@ -409,13 +409,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pydantic"
-version = "2.10.1"
+version = "2.10.2"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.10.1-py3-none-any.whl", hash = "sha256:a8d20db84de64cf4a7d59e899c2caf0fe9d660c7cfc482528e7020d7dd189a7e"},
-    {file = "pydantic-2.10.1.tar.gz", hash = "sha256:a4daca2dc0aa429555e0656d6bf94873a7dc5f54ee42b1f5873d666fb3f35560"},
+    {file = "pydantic-2.10.2-py3-none-any.whl", hash = "sha256:cfb96e45951117c3024e6b67b25cdc33a3cb7b2fa62e239f7af1378358a1d99e"},
+    {file = "pydantic-2.10.2.tar.gz", hash = "sha256:2bc2d7f17232e0841cbba4641e65ba1eb6fafb3a08de3a091ff3ce14a197c4fa"},
 ]
 
 [package.dependencies]
@@ -710,21 +710,23 @@ files = [
 widechars = ["wcwidth"]
 
 [[package]]
-name = "terra-scientific-pipelines-service-api-client"
-version = "0.1.11"
+name = "teaspoons-client"
+version = "0.0.0"
 description = "Terra Scientific Pipelines Service"
 optional = false
-python-versions = "*"
-files = [
-    {file = "terra_scientific_pipelines_service_api_client-0.1.11-py3-none-any.whl", hash = "sha256:6099f2757fbd12b854737b5c8ba98e4694416405ef510a1f858fa9cde85184d9"},
-    {file = "terra_scientific_pipelines_service_api_client-0.1.11.tar.gz", hash = "sha256:912c929512dc26ada932e8cab5a646999782e17b6cdb263a9413f564c31e8249"},
-]
+python-versions = "^3.7"
+files = []
+develop = false
 
 [package.dependencies]
 pydantic = ">=2"
 python-dateutil = ">=2.8.2"
 typing-extensions = ">=4.7.1"
-urllib3 = ">=1.25.3,<3.0.0"
+urllib3 = ">= 1.25.3"
+
+[package.source]
+type = "directory"
+url = "../terra-scientific-pipelines-service/python-client/generated"
 
 [[package]]
 name = "tqdm"
@@ -806,4 +808,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "5c87c55e5995dc1cf015f2a3196654b8dfec1863cebdabebb79b734cc583cd98"
+content-hash = "3c5fcb275101430f75a9dff9902671675212103055d9c9f0ff8db355eda73d0e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-# terra-scientific-pipelines-service-api-client = "0.1.11"
- teaspoons-client = {path = "/Users/jsoto/Documents/repos/terra-scientific-pipelines-service/python-client/generated"}
+terra-scientific-pipelines-service-api-client = "0.1.14"
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-terra-scientific-pipelines-service-api-client = "0.1.11"
+# terra-scientific-pipelines-service-api-client = "0.1.11"
+ teaspoons-client = {path = "/Users/jsoto/Documents/repos/terra-scientific-pipelines-service/python-client/generated"}
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,5 +1,4 @@
 # Teaspoons service API URL
-#TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
 TEASPOONS_API_URL=http://localhost:8080
 
 # Port to use for local server (for auth)

--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,5 +1,6 @@
 # Teaspoons service API URL
-TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
+#TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
+TEASPOONS_API_URL=http://localhost:8080
 
 # Port to use for local server (for auth)
 SERVER_PORT=10444

--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,5 +1,5 @@
 # Teaspoons service API URL
-TEASPOONS_API_URL=http://localhost:8080
+TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
 
 # Port to use for local server (for auth)
 SERVER_PORT=10444

--- a/terralab/commands/auth_commands.py
+++ b/terralab/commands/auth_commands.py
@@ -7,5 +7,5 @@ from terralab.logic import auth_logic
 
 @click.command()
 def logout():
-    """Clear the local authentication token"""
+    """Remove access credentials"""
     auth_logic.clear_local_token()

--- a/terralab/logic/auth_logic.py
+++ b/terralab/logic/auth_logic.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def clear_local_token():
-    """Clear the local authentication token"""
+    """Remove access credentials"""
     cli_config = CliConfig()  # initialize the config from environment variables
     _clear_local_token(cli_config.access_token_file)
     _clear_local_token(cli_config.refresh_token_file)


### PR DESCRIPTION
### Description 
This PR is related to https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/170

This PR does three things
* update commands to only require pipeline name when necessary
* update jobs list command to return the pipeline_name
* change the help text for the logout command (we should talk about this!)

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-382


![Screenshot 2024-12-02 at 12 59 28 PM](https://github.com/user-attachments/assets/bd2c5291-1568-4a74-90e5-0a9818df3d94)

![Screenshot 2024-12-02 at 12 59 21 PM](https://github.com/user-attachments/assets/ad7b5970-88e4-47b9-8b44-9f8a12af9063)

![Screenshot 2024-12-02 at 12 59 14 PM](https://github.com/user-attachments/assets/70660f03-bdd5-4c67-bc0a-08f1eb58347c)

![Screenshot 2024-12-02 at 12 59 07 PM](https://github.com/user-attachments/assets/eec000b1-445f-4f29-a006-cda534d2f1f2)
