### PR TITLE
TSPS-370 Make pipelineVersion acceptable and not required 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -711,13 +711,13 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "terra-scientific-pipelines-service-api-client"
-version = "0.1.14"
+version = "0.1.16"
 description = "Terra Scientific Pipelines Service"
 optional = false
 python-versions = "*"
 files = [
-    {file = "terra_scientific_pipelines_service_api_client-0.1.14-py3-none-any.whl", hash = "sha256:c0880c4e945d728c2f05faa8dac505b65202e423b14317fab29805666f35fbf0"},
-    {file = "terra_scientific_pipelines_service_api_client-0.1.14.tar.gz", hash = "sha256:4ce0a7889e0780cbc7f93470947597b2e705f93b4420dbdefc0c9a8ec5fe22a3"},
+    {file = "terra_scientific_pipelines_service_api_client-0.1.16-py3-none-any.whl", hash = "sha256:b2b25fee38cebd709ff2e6e3f4aec5b7d9f309e27d741feebf0eac260325f374"},
+    {file = "terra_scientific_pipelines_service_api_client-0.1.16.tar.gz", hash = "sha256:8a17677169878be398428eafcecebde8153c7cd7a5059b8541a15a69b2047a16"},
 ]
 
 [package.dependencies]
@@ -806,4 +806,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "077762c663b7a68f54e28c75c27d225a2e0674acab3c4400fc50b52ce75ee861"
+content-hash = "86f1e098753a14282128aefa7eea92fc5c4cc381574a9f45d8f17d64f0cbcf8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-terra-scientific-pipelines-service-api-client = "0.1.14"
+#terra-scientific-pipelines-service-api-client = "0.1.14"
+teaspoons-client = {path = "/Users/jsoto/Documents/repos/terra-scientific-pipelines-service/python-client/generated"}
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-#terra-scientific-pipelines-service-api-client = "0.1.14"
-teaspoons-client = {path = "/Users/jsoto/Documents/repos/terra-scientific-pipelines-service/python-client/generated"}
+terra-scientific-pipelines-service-api-client = "0.1.16"
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,5 +1,6 @@
 # Teaspoons service API URL
-TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
+#TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
+TEASPOONS_API_URL=http://localhost:8080
 
 # Port to use for local server (for auth)
 SERVER_PORT=10444

--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,6 +1,5 @@
 # Teaspoons service API URL
-#TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
-TEASPOONS_API_URL=http://localhost:8080
+TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
 
 # Port to use for local server (for auth)
 SERVER_PORT=10444

--- a/terralab/commands/pipeline_runs_commands.py
+++ b/terralab/commands/pipeline_runs_commands.py
@@ -25,9 +25,7 @@ LOGGER = logging.getLogger(__name__)
 
 @click.command(short_help="Submit a job")
 @click.argument("pipeline_name", type=str)
-@click.option(
-    "--version", type=int, default=0, help="pipeline version; default: 0"
-)  # once TSPS-370 is done, remove default
+@click.option("--version", type=int, help="pipeline version")
 @click.option("--inputs", type=str, required=True, help="JSON string input")
 @click.option(
     "--description", type=str, default="", help="optional description for the job"
@@ -38,7 +36,7 @@ def submit(pipeline_name: str, version: int, inputs: str, description: str):
     inputs_dict = process_json_to_dict(inputs)
 
     # validate inputs
-    pipelines_logic.validate_pipeline_inputs(pipeline_name, inputs_dict)
+    pipelines_logic.validate_pipeline_inputs(pipeline_name, version, inputs_dict)
 
     submitted_job_id = pipeline_runs_logic.prepare_upload_start_pipeline_run(
         pipeline_name, version, inputs_dict, description

--- a/terralab/commands/pipelines_commands.py
+++ b/terralab/commands/pipelines_commands.py
@@ -26,21 +26,26 @@ def list():
 
     for pipeline in pipelines_list:
         LOGGER.info(pipeline.pipeline_name)
+        LOGGER.info(indented("Version: " + str(pipeline.pipeline_version)))
         LOGGER.info(indented(pipeline.description))
 
 
 @pipelines.command(short_help="Get information about a pipeline")
 @click.argument("pipeline_name")
+@click.option("--version", type=int, help="pipeline version")
 @handle_api_exceptions
-def details(pipeline_name: str):
+def details(pipeline_name: str, version: int):
     """Get information about the PIPELINE_NAME pipeline"""
-    pipeline_info = pipelines_logic.get_pipeline_info(pipeline_name)
+    pipeline_info = pipelines_logic.get_pipeline_info(pipeline_name, version)
 
     # format the information nicely
     col_width = 16
 
     LOGGER.info(
         f"{pad_column("Pipeline Name:", col_width)}{pipeline_info.pipeline_name}"
+    )
+    LOGGER.info(
+        f"{pad_column("Pipeline Version:", col_width)}{pipeline_info.pipeline_version}"
     )
     LOGGER.info(f"{pad_column("Description:", col_width)}{pipeline_info.description}")
     LOGGER.info("Inputs:")

--- a/terralab/logic/pipelines_logic.py
+++ b/terralab/logic/pipelines_logic.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from teaspoons_client import PipelinesApi, PipelineWithDetails, Pipeline
+from teaspoons_client import PipelinesApi, PipelineWithDetails, Pipeline, GetPipelineDetailsRequestBody
 
 from terralab.client import ClientWrapper
 from terralab.utils import is_valid_local_file
@@ -24,17 +24,20 @@ def list_pipelines() -> list[Pipeline]:
         return result
 
 
-def get_pipeline_info(pipeline_name: str) -> PipelineWithDetails:
+def get_pipeline_info(pipeline_name: str, version: int) -> PipelineWithDetails:
     """Get the details of a pipeline, returning a dictionary."""
+    get_pipeline_details_request_body : GetPipelineDetailsRequestBody = GetPipelineDetailsRequestBody(
+        pipelineVersion=version
+    )
     with ClientWrapper() as api_client:
         pipeline_client = PipelinesApi(api_client=api_client)
-        return pipeline_client.get_pipeline_details(pipeline_name=pipeline_name)
+        return pipeline_client.get_pipeline_details(pipeline_name, get_pipeline_details_request_body)
 
 
-def validate_pipeline_inputs(pipeline_name: str, inputs_dict: dict):
+def validate_pipeline_inputs(pipeline_name: str, version, inputs_dict: dict):
     """Check that all required user inputs are present, and that all file inputs are valid."""
     # retrieve required pipeline inputs; note currently this endpoint only returns required inputs
-    pipeline_info: PipelineWithDetails = get_pipeline_info(pipeline_name)
+    pipeline_info: PipelineWithDetails = get_pipeline_info(pipeline_name, version)
 
     input_error_messages = []
     expected_input_keys = []

--- a/tests/commands/test_pipeline_runs_commands.py
+++ b/tests/commands/test_pipeline_runs_commands.py
@@ -31,16 +31,47 @@ def test_submit(capture_logs):
         test_inputs_dict
     )
     when(pipeline_runs_commands.pipelines_logic).validate_pipeline_inputs(
-        test_pipeline_name, test_inputs_dict
+        test_pipeline_name, None, test_inputs_dict
     )  # do nothing
 
     when(pipeline_runs_commands.pipeline_runs_logic).prepare_upload_start_pipeline_run(
-        test_pipeline_name, 0, test_inputs_dict, ""
+        test_pipeline_name, None, test_inputs_dict, ""
     ).thenReturn(test_job_id)
 
     result = runner.invoke(
         pipeline_runs_commands.submit,
         [test_pipeline_name, "--inputs", test_inputs_dict_str],
+    )
+
+    assert result.exit_code == 0
+    assert (
+        f"Successfully started {test_pipeline_name} job {test_job_id}"
+        in capture_logs.text
+    )
+
+def test_submit_with_version(capture_logs):
+    runner = CliRunner()
+
+    test_pipeline_name = "test_pipeline"
+    test_inputs_dict = {}
+    test_inputs_dict_str = str(test_inputs_dict)
+
+    test_job_id = uuid.uuid4()
+
+    when(pipeline_runs_commands).process_json_to_dict(test_inputs_dict_str).thenReturn(
+        test_inputs_dict
+    )
+    when(pipeline_runs_commands.pipelines_logic).validate_pipeline_inputs(
+        test_pipeline_name, 1, test_inputs_dict
+    )  # do nothing
+
+    when(pipeline_runs_commands.pipeline_runs_logic).prepare_upload_start_pipeline_run(
+        test_pipeline_name, 1, test_inputs_dict, ""
+    ).thenReturn(test_job_id)
+
+    result = runner.invoke(
+        pipeline_runs_commands.submit,
+        [test_pipeline_name, "--inputs", test_inputs_dict_str, "--version", "1"],
     )
 
     assert result.exit_code == 0


### PR DESCRIPTION
### Description 
Made changes regarding pipeline version
* submit endpoint no longer requires a pipeline version and the service will default to the latest version
* pipeline details now takes an optional pipeline version input, also defaults to latest
* pipeline details and pipelines list now return pipeline version 


Note this will require https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/171 to be merged before it will be working

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-370


Pipelines

![Screenshot 2024-12-02 at 2 30 29 PM](https://github.com/user-attachments/assets/12e1fcc4-c448-4e90-9621-43e7cb650021)
![Screenshot 2024-12-02 at 2 30 48 PM](https://github.com/user-attachments/assets/b4c448ae-67a5-4117-b823-55dd6b81186a)
![Screenshot 2024-12-02 at 2 30 57 PM](https://github.com/user-attachments/assets/944fd10a-2efb-43fa-b0ea-d753f11c1bc3)
![Screenshot 2024-12-02 at 2 31 05 PM](https://github.com/user-attachments/assets/7b7cdc75-f1c0-4a8d-b338-549ddaa60970)

Submit

![Screenshot 2024-12-02 at 2 31 41 PM](https://github.com/user-attachments/assets/a8fed86f-e9a8-4f48-9347-b76be20f2486)
![Screenshot 2024-12-02 at 2 31 55 PM](https://github.com/user-attachments/assets/4edd393c-4d05-4eb9-b053-a7968dee90e8)
![Screenshot 2024-12-02 at 2 32 09 PM](https://github.com/user-attachments/assets/1cad953d-ca75-4857-b294-2eef16bb2fde)
![Screenshot 2024-12-02 at 2 32 31 PM](https://github.com/user-attachments/assets/956efad6-c457-4987-9409-ba3bd3e0a379)
