### PR TITLE
TSPS-388 Process None values in tabulate tables

### DIFF
--- a/terralab/log.py
+++ b/terralab/log.py
@@ -56,8 +56,11 @@ def format_table_with_status(
     # find status column index; this raises a ValueError if the status_key is not found
     status_column_index = headers.index(status_key)
     for single_table_row in rows_list:
+        row_without_none = [
+            "" if x is None else x for x in single_table_row
+        ]  # workaround for https://github.com/astanin/python-tabulate/issues/323
         all_table_rows.append(
-            format_status_in_table_row(single_table_row, status_column_index)
+            format_status_in_table_row(row_without_none, status_column_index)
         )
 
     return tabulate(

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -65,6 +65,11 @@ format_table_with_status_testdata = [
         "State",
         ["Name", "\033[1;37;42mSucceeded\033[0m", "25"],
     ),
+    (  # None input should resolve to empty string
+        [["Name", "Status", "Age"], ["Alice", "SUCCEEDED", None]],
+        "Status",
+        ["Name", "\033[1;37;42mSucceeded\033[0m", ""],
+    ),
 ]
 
 


### PR DESCRIPTION
### Description 

Don't error out if there's a None value in a row to be formatted into a table via tabulate.

Functionally successful in not erroring out when calling `terralab jobs list` with a Preparing job:
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/4548979e-f394-4208-9344-3182a0f39f94">


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-388
