### PR TITLE
TSPS-407 Improve pipelines list output

### DIFF
--- a/terralab/commands/pipelines_commands.py
+++ b/terralab/commands/pipelines_commands.py
@@ -5,7 +5,7 @@ import logging
 
 from terralab.logic import pipelines_logic
 from terralab.utils import handle_api_exceptions
-from terralab.log import indented, pad_column
+from terralab.log import pad_column, format_table
 
 LOGGER = logging.getLogger(__name__)
 
@@ -24,10 +24,11 @@ def list():
         f"Found {len(pipelines_list)} available pipeline{'' if len(pipelines_list) == 1 else 's'}:"
     )
 
+    pipelines_list_rows = [['Name', 'Version', 'Description']]
     for pipeline in pipelines_list:
-        LOGGER.info(pipeline.pipeline_name)
-        LOGGER.info(indented("Version: " + str(pipeline.pipeline_version)))
-        LOGGER.info(indented(pipeline.description))
+        pipelines_list_rows.append([pipeline.pipeline_name, pipeline.pipeline_version, pipeline.description])
+    
+    LOGGER.info(format_table(pipelines_list_rows))
 
 
 @pipelines.command(short_help="Get information about a pipeline")

--- a/terralab/log.py
+++ b/terralab/log.py
@@ -41,9 +41,22 @@ def pad_column(first_string: str, column_width: int = 20):
 def add_blankline_after(string: str):
     return f"{string}\n"
 
+DEFAULT_MAX_COL_SIZE = 60
+
+def format_table(rows_list: list[list[str]], max_col_size: int = DEFAULT_MAX_COL_SIZE
+) -> str:
+    """Provided a list of list of strings representing rows to be formatted into a table,
+    with the headers as the first list of strings, return the formatted (via tabulate package) 
+    string to be logged as a table.
+    """
+
+    return tabulate(
+        rows_list, headers="firstrow", numalign="left", maxcolwidths=max_col_size
+    )
+
 
 def format_table_with_status(
-    rows_list: list[list[str]], status_key: str = "Status", max_col_size: int = 60
+    rows_list: list[list[str]], status_key: str = "Status", max_col_size: int = DEFAULT_MAX_COL_SIZE
 ) -> str:
     """Provided a list of list of strings representing rows to be formatted into a table,
     with the headers as the first list of strings, color-format a Status column's values

--- a/tests/commands/test_pipelines_commands.py
+++ b/tests/commands/test_pipelines_commands.py
@@ -39,8 +39,9 @@ def test_list_pipelines(capture_logs):
     assert result.exit_code == 0
     verify(pipelines_commands.pipelines_logic).list_pipelines()
     assert "Found 2 available pipelines:" in capture_logs.text
-    assert "Version: 1" in capture_logs.text
-    assert "Version: 2" in capture_logs.text
+    assert "Name" in capture_logs.text
+    assert "Version" in capture_logs.text
+    assert "Description" in capture_logs.text
     assert "test_pipeline_1" in capture_logs.text
     assert "test_pipeline_2" in capture_logs.text
 


### PR DESCRIPTION
### Description 

Before:
``` 
> terralab pipelines list
Found 1 available pipeline:
array_imputation
  Version: 0
  Phase and impute genotypes using Beagle 5.4 with the AoU/AnVIL reference panel of 515,579 samples.
```

After:
``` 
> terralab pipelines list
Found 1 available pipeline:
Name              Version    Description
----------------  ---------  ----------------------------------------------------
array_imputation  0          Phase and impute genotypes using Beagle 5.4 with the
                             AoU/AnVIL reference panel of 515,579 samples.
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-407
