### PR TITLE
TSPS-396 add support text to failed run response and API errors

### DIFF
--- a/terralab/commands/pipeline_runs_commands.py
+++ b/terralab/commands/pipeline_runs_commands.py
@@ -6,12 +6,14 @@ import uuid
 
 from teaspoons_client import AsyncPipelineRunResponse, PipelineRun
 
+from terralab.constants import FAILED_KEY
 from terralab.logic import pipeline_runs_logic, pipelines_logic
 from terralab.utils import (
     handle_api_exceptions,
     process_json_to_dict,
     validate_job_id,
     format_timestamp,
+    SUPPORT_TEXT,
 )
 from terralab.log import (
     indented,
@@ -90,6 +92,9 @@ def details(job_id: str):
         LOGGER.info(
             add_blankline_after(f"Error message: {response.error_report.message}")
         )
+    
+    if response.job_report.status == FAILED_KEY:
+        LOGGER.info(add_blankline_after(SUPPORT_TEXT))
 
     LOGGER.info("Details:")
     LOGGER.info(

--- a/terralab/commands/pipeline_runs_commands.py
+++ b/terralab/commands/pipeline_runs_commands.py
@@ -6,14 +6,13 @@ import uuid
 
 from teaspoons_client import AsyncPipelineRunResponse, PipelineRun
 
-from terralab.constants import FAILED_KEY
+from terralab.constants import FAILED_KEY, SUPPORT_EMAIL_TEXT
 from terralab.logic import pipeline_runs_logic, pipelines_logic
 from terralab.utils import (
     handle_api_exceptions,
     process_json_to_dict,
     validate_job_id,
     format_timestamp,
-    SUPPORT_EMAIL_TEXT,
 )
 from terralab.log import (
     indented,
@@ -92,7 +91,7 @@ def details(job_id: str):
         LOGGER.info(
             add_blankline_after(f"Error message: {response.error_report.message}")
         )
-    
+
     if response.job_report.status == FAILED_KEY:
         LOGGER.info(add_blankline_after(SUPPORT_EMAIL_TEXT))
 

--- a/terralab/commands/pipeline_runs_commands.py
+++ b/terralab/commands/pipeline_runs_commands.py
@@ -13,7 +13,7 @@ from terralab.utils import (
     process_json_to_dict,
     validate_job_id,
     format_timestamp,
-    SUPPORT_TEXT,
+    SUPPORT_EMAIL_TEXT,
 )
 from terralab.log import (
     indented,
@@ -94,7 +94,7 @@ def details(job_id: str):
         )
     
     if response.job_report.status == FAILED_KEY:
-        LOGGER.info(add_blankline_after(SUPPORT_TEXT))
+        LOGGER.info(add_blankline_after(SUPPORT_EMAIL_TEXT))
 
     LOGGER.info("Details:")
     LOGGER.info(

--- a/terralab/commands/pipelines_commands.py
+++ b/terralab/commands/pipelines_commands.py
@@ -24,10 +24,12 @@ def list():
         f"Found {len(pipelines_list)} available pipeline{'' if len(pipelines_list) == 1 else 's'}:"
     )
 
-    pipelines_list_rows = [['Name', 'Version', 'Description']]
+    pipelines_list_rows = [["Name", "Version", "Description"]]
     for pipeline in pipelines_list:
-        pipelines_list_rows.append([pipeline.pipeline_name, pipeline.pipeline_version, pipeline.description])
-    
+        pipelines_list_rows.append(
+            [pipeline.pipeline_name, pipeline.pipeline_version, pipeline.description]
+        )
+
     LOGGER.info(format_table(pipelines_list_rows))
 
 

--- a/terralab/constants.py
+++ b/terralab/constants.py
@@ -4,3 +4,6 @@ FAILED_KEY = "FAILED"
 SUCCEEDED_KEY = "SUCCEEDED"
 RUNNING_KEY = "RUNNING"
 PREPARING_KEY = "PREPARING"
+
+# support email address
+SUPPORT_EMAIL = "scientific-services-support@broadinstitute.org"

--- a/terralab/constants.py
+++ b/terralab/constants.py
@@ -1,9 +1,9 @@
-
 # status key values as defined by the Teaspoons service
 FAILED_KEY = "FAILED"
 SUCCEEDED_KEY = "SUCCEEDED"
 RUNNING_KEY = "RUNNING"
 PREPARING_KEY = "PREPARING"
 
-# support email address
+# support text
 SUPPORT_EMAIL = "scientific-services-support@broadinstitute.org"
+SUPPORT_EMAIL_TEXT = f"For help troubleshooting, email {SUPPORT_EMAIL}"

--- a/terralab/constants.py
+++ b/terralab/constants.py
@@ -1,0 +1,6 @@
+
+# status key values as defined by the Teaspoons service
+FAILED_KEY = "FAILED"
+SUCCEEDED_KEY = "SUCCEEDED"
+RUNNING_KEY = "RUNNING"
+PREPARING_KEY = "PREPARING"

--- a/terralab/log.py
+++ b/terralab/log.py
@@ -3,6 +3,7 @@
 import colorlog
 import logging
 from tabulate import tabulate
+from terralab.constants import FAILED_KEY, SUCCEEDED_KEY, RUNNING_KEY, PREPARING_KEY
 
 
 def configure_logging(debug: bool):
@@ -41,12 +42,15 @@ def pad_column(first_string: str, column_width: int = 20):
 def add_blankline_after(string: str):
     return f"{string}\n"
 
+
 DEFAULT_MAX_COL_SIZE = 60
 
-def format_table(rows_list: list[list[str]], max_col_size: int = DEFAULT_MAX_COL_SIZE
+
+def format_table(
+    rows_list: list[list[str]], max_col_size: int = DEFAULT_MAX_COL_SIZE
 ) -> str:
     """Provided a list of list of strings representing rows to be formatted into a table,
-    with the headers as the first list of strings, return the formatted (via tabulate package) 
+    with the headers as the first list of strings, return the formatted (via tabulate package)
     string to be logged as a table.
     """
 
@@ -56,7 +60,9 @@ def format_table(rows_list: list[list[str]], max_col_size: int = DEFAULT_MAX_COL
 
 
 def format_table_with_status(
-    rows_list: list[list[str]], status_key: str = "Status", max_col_size: int = DEFAULT_MAX_COL_SIZE
+    rows_list: list[list[str]],
+    status_key: str = "Status",
+    max_col_size: int = DEFAULT_MAX_COL_SIZE,
 ) -> str:
     """Provided a list of list of strings representing rows to be formatted into a table,
     with the headers as the first list of strings, color-format a Status column's values
@@ -82,10 +88,10 @@ def format_table_with_status(
 
 
 COLORFUL_STATUS = {
-    "FAILED": "\033[1;37;41mFailed\033[0m",
-    "SUCCEEDED": "\033[1;37;42mSucceeded\033[0m",
-    "RUNNING": "\033[0;30;46mRunning\033[0m",
-    "PREPARING": "\033[0;30;43mPreparing\033[0m",
+    FAILED_KEY: "\033[1;37;41mFailed\033[0m",
+    SUCCEEDED_KEY: "\033[1;37;42mSucceeded\033[0m",
+    RUNNING_KEY: "\033[0;30;46mRunning\033[0m",
+    PREPARING_KEY: "\033[0;30;43mPreparing\033[0m",
 }
 
 

--- a/terralab/logic/pipeline_runs_logic.py
+++ b/terralab/logic/pipeline_runs_logic.py
@@ -25,7 +25,11 @@ SIGNED_URL_KEY = "signedUrl"
 
 
 def prepare_pipeline_run(
-    pipeline_name: str, job_id: str, pipeline_version: int, pipeline_inputs: dict, description: str
+    pipeline_name: str,
+    job_id: str,
+    pipeline_version: int,
+    pipeline_inputs: dict,
+    description: str,
 ) -> dict:
     """Call the preparePipelineRun Teaspoons endpoint.
     Return a dictionary of {input_name: signed_url}."""
@@ -35,7 +39,7 @@ def prepare_pipeline_run(
             pipeline_name=pipeline_name,
             pipelineVersion=pipeline_version,
             pipelineInputs=pipeline_inputs,
-            description=description
+            description=description,
         )
     )
 
@@ -55,9 +59,7 @@ def prepare_pipeline_run(
 def start_pipeline_run(job_id: str) -> uuid.UUID:
     """Call the startPipelineRun Teaspoons endpoint and return the Async Job Response."""
     start_pipeline_run_request_body: StartPipelineRunRequestBody = (
-        StartPipelineRunRequestBody(
-            jobControl=JobControl(id=job_id)
-        )
+        StartPipelineRunRequestBody(jobControl=JobControl(id=job_id))
     )
     with ClientWrapper() as api_client:
         pipeline_runs_client = PipelineRunsApi(api_client=api_client)

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -15,13 +15,13 @@ from functools import wraps
 
 from teaspoons_client import ApiException
 
+from terralab.constants import SUPPORT_EMAIL
 from terralab.log import add_blankline_after
 
 
 LOGGER = logging.getLogger(__name__)
 
-# in future make this customizable
-SUPPORT_TEXT = "For further help, email imputation-support@broadinstute.org"
+SUPPORT_EMAIL_TEXT = f"For help troubleshooting, email {SUPPORT_EMAIL}"
 
 
 def handle_api_exceptions(func):
@@ -32,9 +32,11 @@ def handle_api_exceptions(func):
         except ApiException as e:
             formatted_message = f"API call failed with status code {e.status} ({e.reason}): {json.loads(e.body)['message']}"
             LOGGER.error(add_blankline_after(formatted_message))
+            LOGGER.error(add_blankline_after(SUPPORT_EMAIL_TEXT))
             exit(1)
         except Exception as e:
             LOGGER.error(add_blankline_after(str(e)))
+            LOGGER.error(add_blankline_after(SUPPORT_EMAIL_TEXT))
             exit(1)
 
     return wrapper

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -15,13 +15,11 @@ from functools import wraps
 
 from teaspoons_client import ApiException
 
-from terralab.constants import SUPPORT_EMAIL
+from terralab.constants import SUPPORT_EMAIL_TEXT
 from terralab.log import add_blankline_after
 
 
 LOGGER = logging.getLogger(__name__)
-
-SUPPORT_EMAIL_TEXT = f"For help troubleshooting, email {SUPPORT_EMAIL}"
 
 
 def handle_api_exceptions(func):

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -20,6 +20,9 @@ from terralab.log import add_blankline_after
 
 LOGGER = logging.getLogger(__name__)
 
+# in future make this customizable
+SUPPORT_TEXT = "For further help, email imputation-support@broadinstute.org"
+
 
 def handle_api_exceptions(func):
     @wraps(func)

--- a/tests/commands/test_pipeline_runs_commands.py
+++ b/tests/commands/test_pipeline_runs_commands.py
@@ -41,7 +41,13 @@ def test_submit(capture_logs):
 
     result = runner.invoke(
         pipeline_runs_commands.submit,
-        [test_pipeline_name, "--inputs", test_inputs_dict_str, "--description", test_description],
+        [
+            test_pipeline_name,
+            "--inputs",
+            test_inputs_dict_str,
+            "--description",
+            test_description,
+        ],
     )
 
     assert result.exit_code == 0
@@ -49,6 +55,7 @@ def test_submit(capture_logs):
         f"Successfully started {test_pipeline_name} job {test_job_id}"
         in capture_logs.text
     )
+
 
 def test_submit_no_description(capture_logs):
     runner = CliRunner()

--- a/tests/commands/test_pipeline_runs_commands.py
+++ b/tests/commands/test_pipeline_runs_commands.py
@@ -12,6 +12,7 @@ from teaspoons_client import (
     ErrorReport,
     PipelineRunReport,
 )
+from terralab.constants import SUPPORT_EMAIL_TEXT
 from terralab.commands import pipeline_runs_commands
 from tests.utils_for_tests import capture_logs
 
@@ -223,6 +224,7 @@ def test_details_failed_job(capture_logs):
     assert result.exit_code == 0
     assert "Status:" in capture_logs.text
     assert test_error_message in capture_logs.text
+    assert SUPPORT_EMAIL_TEXT in capture_logs.text
     assert "Completed:" in capture_logs.text
 
 

--- a/tests/commands/test_pipelines_commands.py
+++ b/tests/commands/test_pipelines_commands.py
@@ -3,13 +3,15 @@
 import logging
 from click.testing import CliRunner
 from mockito import when, verify
-from terralab.commands import pipelines_commands
+
 from teaspoons_client import (
     Pipeline,
     PipelineWithDetails,
     PipelineUserProvidedInputDefinition,
     ApiException,
 )
+from terralab.constants import SUPPORT_EMAIL_TEXT
+from terralab.commands import pipelines_commands
 from tests.utils_for_tests import capture_logs
 
 LOGGER = logging.getLogger(__name__)
@@ -148,5 +150,6 @@ def test_get_info_api_exception(capture_logs, unstub):
         "API call failed with status code 400 (Error Reason): this is the body message"
         in capture_logs.text
     )
+    assert SUPPORT_EMAIL_TEXT in capture_logs.text
 
     unstub()

--- a/tests/logic/test_pipeline_runs_logic.py
+++ b/tests/logic/test_pipeline_runs_logic.py
@@ -72,7 +72,11 @@ def test_prepare_pipeline_run(mock_pipeline_runs_api):
     ).thenReturn(mock_pipeline_run_response)
 
     result = pipeline_runs_logic.prepare_pipeline_run(
-        test_pipeline_name, test_job_id, test_pipeline_version, test_pipeline_inputs, test_description
+        test_pipeline_name,
+        test_job_id,
+        test_pipeline_version,
+        test_pipeline_inputs,
+        test_description,
     )
 
     assert result == {test_input_name: test_signed_url}
@@ -111,7 +115,11 @@ def test_prepare_pipeline_run_no_description(mock_pipeline_runs_api):
     ).thenReturn(mock_pipeline_run_response)
 
     result = pipeline_runs_logic.prepare_pipeline_run(
-        test_pipeline_name, test_job_id, test_pipeline_version, test_pipeline_inputs, test_description
+        test_pipeline_name,
+        test_job_id,
+        test_pipeline_version,
+        test_pipeline_inputs,
+        test_description,
     )
 
     assert result == {test_input_name: test_signed_url}
@@ -182,16 +190,20 @@ def test_prepare_upload_start_pipeline_run():
     test_signed_url = "signed_url"
     test_upload_url_dict = {test_input_name: test_signed_url}
     when(pipeline_runs_logic).prepare_pipeline_run(
-        test_pipeline_name, test_job_id_str, test_pipeline_version, test_inputs, test_description
+        test_pipeline_name,
+        test_job_id_str,
+        test_pipeline_version,
+        test_inputs,
+        test_description,
     ).thenReturn(test_upload_url_dict)
 
     when(pipeline_runs_logic).upload_file_with_signed_url(
         test_input_value, test_signed_url
     )  # do nothing
 
-    when(pipeline_runs_logic).start_pipeline_run(
-        test_job_id_str
-    ).thenReturn(test_job_id)
+    when(pipeline_runs_logic).start_pipeline_run(test_job_id_str).thenReturn(
+        test_job_id
+    )
 
     response = pipeline_runs_logic.prepare_upload_start_pipeline_run(
         test_pipeline_name, test_pipeline_version, test_inputs, test_description


### PR DESCRIPTION
### Description 

Add the text "For help troubleshooting, email scientific-services-support@broadinstitute.org" to failed job details response and all API error responses.

Example jobs details for a failed job:
```
✗ terralab jobs details 8ef861be-d548-44e6-aeea-312a0eb8c24b
Status: Failed

Error message: Not all runs succeeded for submission: 82099128-b6f7-4236-ad45-061fb1339a26

For help troubleshooting, email scientific-services-support@broadinstitute.org

Details:
  Pipeline Name: array_imputation
  Pipeline Version: 0
  Submitted: 2024-12-11 13:35:27 EST
  Completed: 2024-12-11 13:39:42 EST
  Description: 
```

Error that's not an API error doesn't have the help text:
```
✗ terralab jobs details 8ef861be-d548-44e6-aeea-312a0eb8c24 
Input error: JOB_ID must be a valid uuid.
```

Error that's an API error does have the help text:
```
✗ terralab jobs details 8ef861be-d548-44e6-aeea-312a0eb8c24e
API call failed with status code 404 (Not Found): Pipeline run 8ef861be-d548-44e6-aeea-312a0eb8c24e not found

For help troubleshooting, email scientific-services-support@broadinstitute.org
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-396
