### PR TITLE
TSPS-400 check for output expiration date when trying to download outputs

### DIFF
--- a/terralab/logic/pipeline_runs_logic.py
+++ b/terralab/logic/pipeline_runs_logic.py
@@ -12,7 +12,11 @@ from teaspoons_client import (
     PipelineRun,
 )
 
-from terralab.utils import upload_file_with_signed_url, download_files_with_signed_urls
+from terralab.utils import (
+    upload_file_with_signed_url,
+    download_files_with_signed_urls,
+    timestamp_before_now,
+)
 from terralab.client import ClientWrapper
 from terralab.log import indented
 
@@ -154,6 +158,10 @@ def get_result_and_download_pipeline_run_outputs(
     LOGGER.debug(f"Job {job_id} status is {job_status}")
     if job_status != "SUCCEEDED":
         LOGGER.error(f"Results not available for job {job_id} with status {job_status}")
+        exit(1)
+
+    if timestamp_before_now(result.pipeline_run_report.output_expiration_date):
+        LOGGER.error(f"Results for job {job_id} have expired")
         exit(1)
 
     # extract output signed urls and download them all

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -228,3 +228,16 @@ def format_timestamp(timestamp_string: str) -> str:
         local_timezone
     )
     return datetime_obj.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def timestamp_before_now(timestamp_string: str) -> bool:
+    """Check if a timestamp is before the current time.
+    If timestamp_str is None or empty, return False."""
+    if not timestamp_string:
+        return False
+
+    now = datetime.datetime.now(tzlocal.get_localzone())
+    datetime_obj = datetime.datetime.fromisoformat(timestamp_string).astimezone(
+        tzlocal.get_localzone()
+    )
+    return datetime_obj < now

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 # tests/test_utils
 
 import os
+from datetime import datetime, timedelta
+
 import pytest
 import tempfile
 import uuid
@@ -230,3 +232,18 @@ def test_format_timestamp(timestamp, local_timezone, expected, unstub):
     assert formatted == expected
 
     unstub()
+
+def test_timestamp_before_now():
+    # future timestamp
+    future_timestamp = str(datetime.now() + timedelta(days=1))
+    assert utils.timestamp_before_now(future_timestamp) == False
+
+    # past timestamp
+    past_timestamp = str(datetime.now() - timedelta(days=1))
+    assert utils.timestamp_before_now(past_timestamp) == True
+
+    # empty timestamp
+    assert utils.timestamp_before_now("") == False
+
+    # None timestamp
+    assert utils.timestamp_before_now(None) == False


### PR DESCRIPTION
### Description 

When running the `terralab download`, the CLI should check the output expiration date to know whether or not it should try to download the outputs.  If the expiration date is in the past, display an error to the user

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-400

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
