### PR TITLE
TSPS-425 Run e2e test on merge to main

### DIFF
--- a/.github/workflows/bump-build-publish-cli.yml
+++ b/.github/workflows/bump-build-publish-cli.yml
@@ -130,3 +130,10 @@ jobs:
           author_name: "bump-build-publish-cli workflow"
           icon_emoji: ":triangular_ruler:"
           fields: job, commit
+
+  # Run e2e tests
+  python-client-job:
+    needs: [ tag-job ]
+    uses: ./.github/workflows/run-e2e-tests.yml
+    with:
+      cli-version-ref: ${{ needs.tag-job.outputs.checkout-ref }}

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,10 +1,11 @@
 name: Run Terralab CLI e2e tests with BEE using GCP workspace
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '*.md'
+  workflow_call:
+    inputs:
+      cli-version-ref:
+        description: 'Branch or semantic version (git tag) of CLI repo to use.'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       custom-app-version:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -121,7 +121,6 @@ jobs:
 
       - name: dispatch to terra-github-workflows
         id: FirstAttemptCreateBee
-        continue-on-error: true
         uses: ./.github/actions/create-bee
         with:
           run_name: "bee-create-${{ env.BEE_NAME }}"

--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,6 +1,5 @@
 # Teaspoons service API URL
-# TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
-TEASPOONS_API_URL=http://localhost:8080
+TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
 
 # Port to use for local server (for auth)
 SERVER_PORT=10444

--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,5 +1,6 @@
 # Teaspoons service API URL
-TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
+# TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
+TEASPOONS_API_URL=http://localhost:8080
 
 # Port to use for local server (for auth)
 SERVER_PORT=10444


### PR DESCRIPTION
### Description 

This PR changes the GHA workflow logic to run e2e tests as part of the build-publish workflow (which is run on merge to main), allowing us to set the tag to the new one created when publishing it.

Also remove `continue-on-retry` from the bee-create job (this was a vestige of having a retry-bee-create job that never worked so we removed it)

### Jira Ticket


### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
