### PR TITLE
TSPS-419 Restrict permissions on token files

### DIFF
--- a/terralab/auth_helper.py
+++ b/terralab/auth_helper.py
@@ -218,7 +218,8 @@ def _save_local_token(token_file: str, token: str):
 
     descriptor = os.open(
         token_file,
-        os.O_WRONLY | os.O_CREAT, 0o600
+        os.O_WRONLY | os.O_CREAT, 
+        0o600  # equivalent of chmod 600, i.e. no access for anyone besides current user
     )
     with os.fdopen(descriptor, "w") as f:
         f.write(token)

--- a/terralab/auth_helper.py
+++ b/terralab/auth_helper.py
@@ -215,5 +215,10 @@ def _load_local_token(token_file: str, validate: bool = True) -> t.Optional[str]
 def _save_local_token(token_file: str, token: str):
     # Create the containing directory if it doesn't exist
     os.makedirs(os.path.dirname(token_file), exist_ok=True)
-    with open(token_file, "w") as f:
+
+    descriptor = os.open(
+        token_file,
+        os.O_WRONLY | os.O_CREAT, 0o600
+    )
+    with os.fdopen(descriptor, "w") as f:
         f.write(token)

--- a/tests/test_auth_helper.py
+++ b/tests/test_auth_helper.py
@@ -2,6 +2,7 @@
 
 import builtins
 import logging
+import os
 
 import pytest
 from jwt import ExpiredSignatureError
@@ -528,10 +529,12 @@ def test_save_local_token(mock_builtin_open, unstub):
     mock_access_token_file = mock()
     mock_token = mock()
     mock_dirname = mock()
+    mock_descriptor = mock()
 
     when(auth_helper.os.path).dirname(mock_access_token_file).thenReturn(mock_dirname)
     when(auth_helper.os).makedirs(mock_dirname, exist_ok=True).thenReturn(None)
-    when(mock_builtin_open).write().thenReturn(None)
+    when(auth_helper.os).open(mock_access_token_file, os.O_WRONLY | os.O_CREAT, 0o600).thenReturn(mock_descriptor)
+    when(auth_helper.os).write().thenReturn(None)
 
     auth_helper._save_local_token(mock_access_token_file, mock_token)
 

--- a/tests/test_auth_helper.py
+++ b/tests/test_auth_helper.py
@@ -534,7 +534,13 @@ def test_save_local_token(mock_builtin_open, unstub):
     when(auth_helper.os.path).dirname(mock_access_token_file).thenReturn(mock_dirname)
     when(auth_helper.os).makedirs(mock_dirname, exist_ok=True).thenReturn(None)
     when(auth_helper.os).open(mock_access_token_file, os.O_WRONLY | os.O_CREAT, 0o600).thenReturn(mock_descriptor)
-    when(auth_helper.os).write().thenReturn(None)
+    
+    mock_fdopen = mock()
+    when(mock_fdopen).__enter__().thenReturn(mock_fdopen)
+    when(mock_fdopen).__exit__(None, None, None).thenReturn(None)
+    when(auth_helper.os).fdopen(mock_descriptor, "w").thenReturn(mock_fdopen)
+
+    when(mock_fdopen).write().thenReturn(None)
 
     auth_helper._save_local_token(mock_access_token_file, mock_token)
 


### PR DESCRIPTION
### Description 

Addresses security finding that the access and refresh token files were being created with read access for other users on the machine:
```
✗ ls -l ~/.terralab      
total 16
-rw-r--r--@ 1 marymorg  staff  1582 Jan 29 14:11 access_token
-rw-r--r--@ 1 marymorg  staff  1774 Jan 29 14:11 refresh_token
```

With this PR, only the user running the command gets access to the files:
```
✗ ls -l ~/.terralab
total 16
-rw-------@ 1 marymorg  staff  1592 Jan 29 14:16 access_token
-rw-------@ 1 marymorg  staff  1780 Jan 29 14:16 refresh_token
```

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-419

### Checklist (provide links to changes)

- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
