### PR TITLE
TSPS-397 Add help text to terralab -h

### DIFF
--- a/terralab/cli.py
+++ b/terralab/cli.py
@@ -54,6 +54,11 @@ class OrderedGroup(click.Group):
     help="DEBUG-level logging",
 )
 def cli(debug):
+    """To submit a job, run `terralab submit PIPELINE_NAME [INPUTS] --description DESCRIPTION`
+
+    For more information about the required inputs for a pipeline, run `terralab pipelines details PIPELINE_NAME`
+
+    To list available pipelines, run `terralab pipelines list`"""
     log.configure_logging(debug)
     LOGGER.debug(
         "Log level set to: %s", logging.getLevelName(logging.getLogger().level)


### PR DESCRIPTION
### Description 

Adding some high-level help text intended to help users get started with terralab.

```
✗ terralab -h
Usage: terralab [OPTIONS] COMMAND [ARGS]...

  To submit a job, run `terralab submit PIPELINE_NAME [INPUTS] --description
  DESCRIPTION`

  For more information about the required inputs for a pipeline, run `terralab
  pipelines details PIPELINE_NAME`

  To list available pipelines, run `terralab pipelines list`

Options:
  --version   Show the version and exit.
  -h, --help  Show this message and exit.

Commands:
  submit               Submit a job
  download             Download all output files from a job
  jobs                 Get information about your jobs
    jobs list          List your jobs
    jobs details       Get the status and details of a job
  pipelines            Get information about available pipelines
    pipelines list     List all available pipelines
    pipelines details  Get information about a pipeline
  quota                Get quota information
  logout               Remove access credentials
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-397

### Checklist (provide links to changes)

- [x] Test that auth flow still works, since this isn't covered by tests (run `terralab logout` and then `terralab pipelines list`)
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
