### PR TITLE
TSPS-405 Add quota units to quota info response

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1620,13 +1620,13 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "terra-scientific-pipelines-service-api-client"
-version = "0.1.40"
+version = "0.1.42"
 description = "Terra Scientific Pipelines Service"
 optional = false
 python-versions = "*"
 files = [
-    {file = "terra_scientific_pipelines_service_api_client-0.1.40-py3-none-any.whl", hash = "sha256:34c4ee16f0afed1f5c33bcb4f3f2b647855fdeb4e833f6f189e450dd88e0049a"},
-    {file = "terra_scientific_pipelines_service_api_client-0.1.40.tar.gz", hash = "sha256:7e4c69f95f0d656e600e5fc4516bfa804f5375dc81f32c38a33784ad9f5a4c25"},
+    {file = "terra_scientific_pipelines_service_api_client-0.1.42-py3-none-any.whl", hash = "sha256:47c2013d7c34222314ee92bfed38e1dc7c2003b1d65d7e753375f2e47393ce6f"},
+    {file = "terra_scientific_pipelines_service_api_client-0.1.42.tar.gz", hash = "sha256:d81d1ee41a32e4e8454bd36c27337fdbca30f048f0d7617349c73e42bd571333"},
 ]
 
 [package.dependencies]
@@ -1867,4 +1867,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "680ee1e41a1bafe5d8be755675bde681e50df5da9c30c35ba582662a8b1db4b5"
+content-hash = "e2f56251fccff2eb9d5588e8073f7688f3021fe1e8955608fa1674c8b7a4f633"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-terra-scientific-pipelines-service-api-client = "0.1.40" # TODO update once service PR is merged
+terra-scientific-pipelines-service-api-client = "0.1.42"
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-terra-scientific-pipelines-service-api-client = "0.1.40"
+terra-scientific-pipelines-service-api-client = "0.1.40" # TODO update once service PR is merged
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/terralab/auth_helper.py
+++ b/terralab/auth_helper.py
@@ -173,7 +173,7 @@ def _exchange_code_for_response(
     if "error" in json_response:
         # see https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#error-response-1
         LOGGER.debug(
-            f"Error in authentication flow exchanging code for response: {json_response["error"]}; error description: {json_response["error_description"]}"
+            f'Error in authentication flow exchanging code for response: {json_response["error"]}; error description: {json_response["error_description"]}'
         )
     else:
         LOGGER.debug("Token refresh successful")

--- a/terralab/commands/quotas_commands.py
+++ b/terralab/commands/quotas_commands.py
@@ -20,7 +20,10 @@ def quota(pipeline_name: str) -> None:
     quota_limit = quota_info.quota_limit
     quota_consumed = quota_info.quota_consumed
     quota_pipeline = quota_info.pipeline_name
+    quota_units = quota_info.quota_units
     LOGGER.info(f"Pipeline: {quota_pipeline}")
-    LOGGER.info(indented(f"Quota Limit: {quota_limit}"))
-    LOGGER.info(indented(f"Quota Used: {quota_consumed}"))
-    LOGGER.info(indented(f"Quota Available: {quota_limit - quota_consumed}"))
+    LOGGER.info(indented(f"Quota Limit: {quota_limit} {quota_units}"))
+    LOGGER.info(indented(f"Quota Used: {quota_consumed} {quota_units}"))
+    LOGGER.info(
+        indented(f"Quota Available: {quota_limit - quota_consumed} {quota_units}")
+    )

--- a/tests/commands/test_quotas_commands.py
+++ b/tests/commands/test_quotas_commands.py
@@ -11,7 +11,10 @@ from tests.utils_for_tests import capture_logs
 def test_get_info_success(capture_logs, unstub):
     test_pipeline_name = "test_pipeline"
     test_quota_details = QuotaWithDetails(
-        pipeline_name=test_pipeline_name, quota_limit=1000, quota_consumed=300
+        pipeline_name=test_pipeline_name,
+        quota_limit=1000,
+        quota_consumed=300,
+        quota_units="samples",
     )
 
     when(quotas_commands.quotas_logic).get_user_quota(test_pipeline_name).thenReturn(
@@ -25,11 +28,11 @@ def test_get_info_success(capture_logs, unstub):
     verify(quotas_commands.quotas_logic).get_user_quota(test_pipeline_name)
     assert test_pipeline_name in capture_logs.text
     # quota limit
-    assert "Quota Limit: 1000" in capture_logs.text
+    assert "Quota Limit: 1000 samples" in capture_logs.text
     # quota consumed
-    assert "Quota Used: 300" in capture_logs.text
+    assert "Quota Used: 300 samples" in capture_logs.text
     # quota left
-    assert "Quota Available: 700" in capture_logs.text
+    assert "Quota Available: 700 samples" in capture_logs.text
 
     unstub()
 

--- a/tests/logic/test_quotas_logic.py
+++ b/tests/logic/test_quotas_logic.py
@@ -38,7 +38,10 @@ def mock_quotas_api(mock_client_wrapper, unstub):
 def test_get_user_quota(mock_quotas_api):
     pipeline_name = "Test Pipeline"
     mock_quota = QuotaWithDetails(
-        pipeline_name=pipeline_name, quota_limit=1000, quota_consumed=300
+        pipeline_name=pipeline_name,
+        quota_limit=1000,
+        quota_consumed=300,
+        quota_units="samples",
     )
     when(mock_quotas_api).get_quota_for_pipeline(
         pipeline_name=pipeline_name
@@ -49,3 +52,4 @@ def test_get_user_quota(mock_quotas_api):
     assert mock_quota.pipeline_name == result.pipeline_name
     assert mock_quota.quota_limit == result.quota_limit
     assert mock_quota.quota_consumed == result.quota_consumed
+    assert mock_quota.quota_units == result.quota_units


### PR DESCRIPTION
### Description 

We've added quota units to be displayed to the user when they request their quota info:
```
✗ terralab quota array_imputation
Pipeline: array_imputation
  Quota Limit: 10000 samples
  Quota Used: 500 samples
  Quota Available: 9500 samples
```

Note tests will fail here until the service PR is merged and this PR has been updated with the new client version.

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-405

### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests (run `terralab logout` and then `terralab pipelines list`)
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [x] Updated Teaspoons PR: https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/205
