### PR TITLE
TSPS-406 Add disclaimer about quota update time

### DIFF
--- a/terralab/commands/quotas_commands.py
+++ b/terralab/commands/quotas_commands.py
@@ -20,6 +20,9 @@ def quota(pipeline_name: str) -> None:
     quota_limit = quota_info.quota_limit
     quota_consumed = quota_info.quota_consumed
     quota_pipeline = quota_info.pipeline_name
+    LOGGER.info(
+        "Note: It may take a few minutes for recently submitted jobs to be reflected."
+    )
     LOGGER.info(f"Pipeline: {quota_pipeline}")
     LOGGER.info(indented(f"Quota Limit: {quota_limit}"))
     LOGGER.info(indented(f"Quota Used: {quota_consumed}"))

--- a/tests/commands/test_quotas_commands.py
+++ b/tests/commands/test_quotas_commands.py
@@ -23,6 +23,10 @@ def test_get_info_success(capture_logs, unstub):
 
     assert result.exit_code == 0
     verify(quotas_commands.quotas_logic).get_user_quota(test_pipeline_name)
+    assert (
+        "Note: It may take a few minutes for recently submitted jobs to be reflected."
+        in capture_logs.text
+    )
     assert test_pipeline_name in capture_logs.text
     # quota limit
     assert "Quota Limit: 1000" in capture_logs.text


### PR DESCRIPTION
### Description 

Because we run a wdl to calculate the quota for a pipeline run, there's a lag of a few minutes between when a user submits a job and that job being factored into their quota as returned by `terralab quota array_imputation`. Here we're adding a note to the CLI output of that call to warn users about this delay.

```
✗ terralab quota array_imputation
Note: It may take a few minutes for recently submitted jobs to be reflected.
Pipeline: array_imputation
  Quota Limit: 10000
  Quota Used: 4000
  Quota Available: 6000
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-406

### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests (run `terralab logout` and then `terralab pipelines list`)
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
