### PR TITLE
add a flush() when writing out tokens to local disk

### DIFF
--- a/terralab/auth_helper.py
+++ b/terralab/auth_helper.py
@@ -225,3 +225,4 @@ def _save_local_token(token_file: str, token: str) -> None:
     )
     with os.fdopen(descriptor, "w") as f:
         f.write(token)
+        f.flush()


### PR DESCRIPTION
### Description 

we saw some weirdness with requests made with the retry and thought the issue might be the token isnt getting written out fully.  No way to know if they actually helped until it happens again 

### Jira Ticket
N/A

### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
