### PR TITLE
TSPS-420 Point CLI to prod Teaspoons

### DIFF
--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,13 +1,12 @@
 # Teaspoons service API URL
-TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
+TEASPOONS_API_URL=https://teaspoons.dsde-prod.broadinstitute.org
 
 # Port to use for local server (for auth)
 SERVER_PORT=10444
 
 # Oauth config stuff
-OAUTH_OPENID_CONFIGURATION_URI=https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin_dev/v2.0/.well-known/openid-configuration
-OAUTH_CLIENT_ID=bbd07d43-01cb-4b69-8fd0-5746d9a5c9fe
+OAUTH_OPENID_CONFIGURATION_URI=https://terraprodb2c.b2clogin.com/terraprodb2c.onmicrosoft.com/b2c_1a_signup_signin_prod/v2.0/.well-known/openid-configuration
+OAUTH_CLIENT_ID=bbd07d43-01cb-4b69-8fd0-5746d9a5c9fe # NEED TO UPDATE
 
 # Terralab storage (absolute path or relative to user's home directory)
 LOCAL_STORAGE_PATH=.terralab
-


### PR DESCRIPTION
### Description 

Now that Teaspoons is deployed to production, we want to point the CLI to prod Teaspoons. This means updating both the teaspoons api url and the b2c configuration values in the terralab config.

Related PRs:
- update cli e2e test config: https://github.com/broadinstitute/dsp-reusable-workflows/pull/74
- configure separate b2c client for terralab: https://github.com/broadinstitute/terraform-ap-deployments/pull/1824

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-420

### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
