### PR TITLE
TSPS-389 make color for info logs consistent with terminal settings

### DIFF
--- a/terralab/log.py
+++ b/terralab/log.py
@@ -17,7 +17,6 @@ def configure_logging(debug: bool) -> None:
             "%(log_color)s%(message)s",
             log_colors={
                 "DEBUG": "cyan",
-                "INFO": "white",
                 "WARNING": "yellow",
                 "ERROR": "red",
                 "CRITICAL": "red,bg_white",

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -29,7 +29,10 @@ def handle_api_exceptions(func: Any) -> Any:
         except ApiException as e:
             message = None
             if e.body is not None:
-                message = json.loads(e.body)["message"]
+                try:
+                    message = json.loads(e.body)["message"]
+                except json.JSONDecodeError:
+                    message = e.body
             if e.status == 401 and message == "User not found":
                 LOGGER.error(
                     add_blankline_before(


### PR DESCRIPTION
### Description 
Essentially when you set a value it can clash with a users terminal settings and produce a "worse" outcome.  Since info logs are what is logged the most we prob dont want to cause an issue with users terminal settings but we have some options

There are two options, we can either do this where we dont set a value for info logs so the user will just see w/e their terminal default color is or we set it to `light_white` which doesnt seem to be [supported by all terminals](https://stackoverflow.com/a/76150559)

Before
![Screenshot 2025-03-29 at 9 40 59 PM](https://github.com/user-attachments/assets/b25c623e-6d75-43a9-b29c-86a1ca6a9601)

With No Value
![Screenshot 2025-03-29 at 9 41 21 PM](https://github.com/user-attachments/assets/a854af54-45a6-4dc7-aba4-dba2437b984b)

With `light_white`
![Screenshot 2025-03-29 at 9 41 06 PM](https://github.com/user-attachments/assets/480dd315-f086-4064-bc12-356e23e81d9a)

I also added a fix for when we get a response that isnt a json (like when we get a 403 page because we arent on vpn).  This makes it so the message is at least printed out to the user instead of a big stack trace

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-389


### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
