### PR TITLE
TSPS-383 Clean up connection error messages

### DIFF
--- a/terralab/log.py
+++ b/terralab/log.py
@@ -112,3 +112,27 @@ def format_status_in_table_row(
 
 def format_status(status_str: str) -> str:
     return COLORFUL_STATUS[status_str]
+
+
+# This filter makes the retry messages from urllib3 more user-friendly.
+# Previously they would show up as ugly errors, i.e.
+#       Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None))
+#       after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection
+#       object at 0x102c47ef0>: Failed to establish a new connection: [Errno 61]
+#       Connection refused')': /api/pipelineruns/v1/pipelineruns?limit=10
+
+
+class RetryMessageFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Matches the retry warning messages produced by urllib3
+        if (
+            "Retrying (" in record.getMessage()
+            and "after connection broken by" in record.getMessage()
+        ):
+            record.msg = "terralab encountered a problem connecting to the server. Retrying your request..."
+            record.args = ()
+        return True
+
+
+urllib3_logger = logging.getLogger("urllib3.connectionpool")
+urllib3_logger.addFilter(RetryMessageFilter())

--- a/terralab/log.py
+++ b/terralab/log.py
@@ -131,6 +131,12 @@ class RetryMessageFilter(logging.Filter):
         ):
             record.msg = "terralab encountered a problem connecting to the server. Retrying your request..."
             record.args = ()
+            record.levelno = logging.DEBUG
+            record.levelname = "DEBUG"
+
+            # Ensures that we still abide by the global logging level
+            if logging.getLogger().getEffectiveLevel() > logging.DEBUG:
+                return False
         return True
 
 

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -52,7 +52,7 @@ def handle_api_exceptions(func: Any) -> Any:
         except MaxRetryError:
             LOGGER.error(
                 add_blankline_before(
-                    "Maximum retries reached. The server may be down or unreachable. Please try again later."
+                    "The server may be down or unreachable. Maximum retries reached. Please try again later."
                 )
             )
             LOGGER.error(add_blankline_before(SUPPORT_EMAIL_TEXT))

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -52,7 +52,8 @@ def handle_api_exceptions(func: Any) -> Any:
         except MaxRetryError:
             LOGGER.error(
                 add_blankline_before(
-                    "The server may be down or unreachable. Maximum retries reached. Please try again later."
+                    "Unable to connect to the server after multiple retries. "
+                    "The server may be down or unreachable. Please try again later."
                 )
             )
             LOGGER.error(add_blankline_before(SUPPORT_EMAIL_TEXT))

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -257,27 +257,3 @@ def format_timestamp(timestamp_string: str | None) -> str:
         local_timezone
     )
     return datetime_obj.strftime("%Y-%m-%d %H:%M:%S %Z")
-
-
-# This is a workaround to make the retry messages from urllib3 more user-friendly.
-# Previously they would show up as ugly errors, i.e.
-#   Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None))
-#   after connection broken by 'NewConnectionError('<urllib3.connection.HTTPConnection
-#   object at 0x102c47ef0>: Failed to establish a new connection: [Errno 61]
-#   Connection refused')': /api/pipelineruns/v1/pipelineruns?limit=10
-
-
-class RetryMessageFilter(logging.Filter):
-    def filter(self, record: logging.LogRecord) -> bool:
-        # Matches the retry warning messages produced by urllib3
-        if (
-            "Retrying (" in record.getMessage()
-            and "after connection broken by" in record.getMessage()
-        ):
-            record.msg = "terralab encountered a problem connecting to the server. Retrying your request..."
-            record.args = ()
-        return True
-
-
-urllib3_logger = logging.getLogger("urllib3.connectionpool")
-urllib3_logger.addFilter(RetryMessageFilter())

--- a/tests/commands/test_pipelines_commands.py
+++ b/tests/commands/test_pipelines_commands.py
@@ -245,7 +245,7 @@ def test_non_json_api_exception_body(capture_logs, unstub):
         ApiException(
             status=403,
             reason=None,
-            body='403 Forbidden: blah blahbalh',
+            body="403 Forbidden: blah blahbalh",
         )
     )
 
@@ -253,9 +253,6 @@ def test_non_json_api_exception_body(capture_logs, unstub):
 
     assert result.exit_code != 0
     verify(pipelines_commands.pipelines_logic).get_pipeline_info(pipeline_name, None)
-    assert (
-        "403 Forbidden: blah blahbalh"
-        in capture_logs.text
-    )
+    assert "403 Forbidden: blah blahbalh" in capture_logs.text
 
     unstub()

--- a/tests/commands/test_pipelines_commands.py
+++ b/tests/commands/test_pipelines_commands.py
@@ -245,7 +245,7 @@ def test_non_json_api_exception_body(capture_logs, unstub):
         ApiException(
             status=403,
             reason=None,
-            body="403 Forbidden: blah blahbalh",
+            body="403 Forbidden: blah blah blah",
         )
     )
 

--- a/tests/commands/test_pipelines_commands.py
+++ b/tests/commands/test_pipelines_commands.py
@@ -253,6 +253,6 @@ def test_non_json_api_exception_body(capture_logs, unstub):
 
     assert result.exit_code != 0
     verify(pipelines_commands.pipelines_logic).get_pipeline_info(pipeline_name, None)
-    assert "403 Forbidden: blah blahbalh" in capture_logs.text
+    assert "403 Forbidden: blah blah blah" in capture_logs.text
 
     unstub()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,8 +8,10 @@ import zoneinfo
 import pytest
 from mockito import mock, when
 from requests.exceptions import HTTPError
+from urllib3.exceptions import MaxRetryError
 
 from terralab import utils
+from terralab.utils import handle_api_exceptions
 from tests.utils_for_tests import capture_logs
 
 process_inputs_testdata = [
@@ -183,6 +185,20 @@ def test_validate_uuid(capture_logs):
     with pytest.raises(SystemExit):
         utils.validate_job_id(None)
     assert "Error: JOB_ID must be a valid uuid." in capture_logs.text
+
+
+def test_server_unavailable_error(capture_logs):
+    @handle_api_exceptions
+    def mock_retry_function():
+        raise MaxRetryError(None, "Just a test")
+
+    with pytest.raises(SystemExit):
+        mock_retry_function()
+
+    assert (
+        "Maximum retries reached. The server may be down or unreachable. Please try again later."
+        in capture_logs.text
+    )
 
 
 format_timestamp_testdata = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,8 +9,6 @@ import pytest
 from mockito import mock, when
 from requests.exceptions import HTTPError
 from urllib3.exceptions import MaxRetryError
-import logging
-from terralab.utils import RetryMessageFilter
 from terralab import utils
 from terralab.utils import handle_api_exceptions
 from tests.utils_for_tests import capture_logs
@@ -200,50 +198,6 @@ def test_server_unavailable_error(capture_logs):
         "Maximum retries reached. The server may be down or unreachable. Please try again later."
         in capture_logs.text
     )
-
-
-def test_retry_message_filter_match():
-    filter_instance = RetryMessageFilter()
-
-    record = logging.LogRecord(
-        name="urllib3.connectionpool",
-        level=logging.WARNING,
-        pathname="test_path",
-        lineno=10,
-        msg="Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) "
-        "after connection broken by 'NewConnectionError': /api/test",
-        args=(),
-        exc_info=None,
-    )
-
-    result = filter_instance.filter(record)
-
-    assert result is True
-    assert (
-        record.msg
-        == "terralab encountered a problem connecting to the server. Retrying your request..."
-    )
-    assert record.args == ()
-
-
-# Tests that we don't clobber other non-retry log messages
-def test_retry_message_filter_non_match():
-    filter_instance = RetryMessageFilter()
-
-    non_matching_record = logging.LogRecord(
-        name="urllib3.connectionpool",
-        level=logging.WARNING,
-        pathname="test_path",
-        lineno=10,
-        msg="Some other log message",
-        args=(),
-        exc_info=None,
-    )
-
-    result = filter_instance.filter(non_matching_record)
-
-    assert result is True
-    assert non_matching_record.msg == "Some other log message"
 
 
 format_timestamp_testdata = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,8 @@ import pytest
 from mockito import mock, when
 from requests.exceptions import HTTPError
 from urllib3.exceptions import MaxRetryError
-
+import logging
+from terralab.utils import RetryMessageFilter
 from terralab import utils
 from terralab.utils import handle_api_exceptions
 from tests.utils_for_tests import capture_logs
@@ -199,6 +200,50 @@ def test_server_unavailable_error(capture_logs):
         "Maximum retries reached. The server may be down or unreachable. Please try again later."
         in capture_logs.text
     )
+
+
+def test_retry_message_filter_match():
+    filter_instance = RetryMessageFilter()
+
+    record = logging.LogRecord(
+        name="urllib3.connectionpool",
+        level=logging.WARNING,
+        pathname="test_path",
+        lineno=10,
+        msg="Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) "
+        "after connection broken by 'NewConnectionError': /api/test",
+        args=(),
+        exc_info=None,
+    )
+
+    result = filter_instance.filter(record)
+
+    assert result is True
+    assert (
+        record.msg
+        == "terralab encountered a problem connecting to the server. Retrying your request..."
+    )
+    assert record.args == ()
+
+
+# Tests that we don't clobber other non-retry log messages
+def test_retry_message_filter_non_match():
+    filter_instance = RetryMessageFilter()
+
+    non_matching_record = logging.LogRecord(
+        name="urllib3.connectionpool",
+        level=logging.WARNING,
+        pathname="test_path",
+        lineno=10,
+        msg="Some other log message",
+        args=(),
+        exc_info=None,
+    )
+
+    result = filter_instance.filter(non_matching_record)
+
+    assert result is True
+    assert non_matching_record.msg == "Some other log message"
 
 
 format_timestamp_testdata = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -195,7 +195,8 @@ def test_server_unavailable_error(capture_logs):
         mock_retry_function()
 
     assert (
-        "The server may be down or unreachable. Maximum retries reached. Please try again later."
+        "Unable to connect to the server after multiple retries. "
+        "The server may be down or unreachable. Please try again later."
         in capture_logs.text
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -195,7 +195,7 @@ def test_server_unavailable_error(capture_logs):
         mock_retry_function()
 
     assert (
-        "Maximum retries reached. The server may be down or unreachable. Please try again later."
+        "The server may be down or unreachable. Maximum retries reached. Please try again later."
         in capture_logs.text
     )
 


### PR DESCRIPTION
### Description 

Before:
<img width="675" alt="Screenshot 2025-05-07 at 3 33 14 PM" src="https://github.com/user-attachments/assets/fccbf424-6b94-4eb9-b63c-8042443a8b7d" />

After:
Running CLI w/o debug mode set:
<img width="717" alt="Screenshot 2025-05-08 at 4 20 08 PM" src="https://github.com/user-attachments/assets/83b93b23-2265-46ac-a904-4192e8bf24e9" />


Running CLI w/ debug mode set:
<img width="716" alt="Screenshot 2025-05-08 at 4 21 08 PM" src="https://github.com/user-attachments/assets/897d9902-11ce-4b25-bd27-2eac6b305014" />


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-383

### Checklist (provide links to changes)

- [x] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
