### PR TITLE
[TSPS-499] Open login page with custom b2c branding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-terra-scientific-pipelines-service-api-client = "1.0.0"
+terra-scientific-pipelines-service-api-client = "1.0.14"
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-terra-scientific-pipelines-service-api-client = "1.0.14"
+terra-scientific-pipelines-service-api-client = "1.0.0"
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/terralab/auth_helper.py
+++ b/terralab/auth_helper.py
@@ -86,7 +86,7 @@ def get_tokens_with_browser_open(cli_config: CliConfig) -> tuple[str, str]:
     client_info = cli_config.client_info
 
     auth_url = get_auth_url(client_info, callback_server.callback_url)
-    _open_browser(f"{auth_url}&prompt=login", LOGGER.info)
+    _open_browser(f"{auth_url}&prompt=login&brand=scientificServices", LOGGER.info)
     code = callback_server.wait_for_code()
     if code is None:
         raise ValueError("No code could be obtained from browser callback page")

--- a/tests/test_auth_helper.py
+++ b/tests/test_auth_helper.py
@@ -217,6 +217,33 @@ def test_get_access_token_with_browser_open_no_code(mock_cli_config, unstub):
     unstub()
 
 
+def test_get_tokens_with_browser_opens_with_brand(mock_cli_config, unstub):
+    mock_callback_server = mock()
+    expected_auth_url = "https://test/url"
+    expected_url = f"{expected_auth_url}&prompt=login&brand=scientificServices"
+    exchange_response_dict = {
+        "access_token": "accesstoken",
+        "refresh_token": "refreshtoken",
+    }
+
+    when(auth_helper).OAuthCallbackHttpServer(mock_cli_config.server_port).thenReturn(
+        mock_callback_server
+    )
+    when(auth_helper).get_auth_url(mock_cli_config.client_info, ...).thenReturn(
+        expected_auth_url
+    )
+    when(auth_helper)._open_browser(...).thenReturn(None)
+    when(mock_callback_server).wait_for_code().thenReturn("code")
+    when(auth_helper)._exchange_code_for_response(...).thenReturn(
+        exchange_response_dict
+    )
+
+    auth_helper.get_tokens_with_browser_open(mock_cli_config)
+
+    verify(auth_helper)._open_browser(expected_url, ...)
+    unstub()
+
+
 def test_open_browser(capture_logs, unstub):
     test_url = "http://test/url"
 


### PR DESCRIPTION
### Description 

Opens the login page with the custom Scientific Services branding.

Note that this will not show any branding differences until the terraform PR is applied ([link](https://github.com/broadinstitute/terraform-ap-deployments/pull/1874)). However, you can still have some confidence that this change has the intended effect by following these steps:

1) Run `terralab logout`
2) Run `terralab pipelines list`
3) Note that `&brand=scientificServices` is now at the end of the login page URL

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-499

### Checklist (provide links to changes)

- [x] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
