### PR TITLE
TSPS-513 add min quota consumed to pipelines details command response

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1539,18 +1539,18 @@ all = ["numpy"]
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.4"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
-    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+    {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
+    {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<3"
 
@@ -1652,13 +1652,13 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "terra-scientific-pipelines-service-api-client"
-version = "1.0.14"
+version = "1.0.16"
 description = "Terra Scientific Pipelines Service"
 optional = false
 python-versions = "*"
 files = [
-    {file = "terra_scientific_pipelines_service_api_client-1.0.14-py3-none-any.whl", hash = "sha256:4e4baea74d124d56f2cd2983e70c795fcb21f1e86d6048be537416eabb5d4114"},
-    {file = "terra_scientific_pipelines_service_api_client-1.0.14.tar.gz", hash = "sha256:708725c093193de3a8e1f56b7ee68a5a02fc954e106226bd6c5b3f5bb647641c"},
+    {file = "terra_scientific_pipelines_service_api_client-1.0.16-py3-none-any.whl", hash = "sha256:b63da47fd5a85756c60c5df8997aec71e01d94bf400971c9df0730329278b841"},
+    {file = "terra_scientific_pipelines_service_api_client-1.0.16.tar.gz", hash = "sha256:c320775db3195789e99959d17ece59cbc514ad7a238717485e7b334e9fea3ea3"},
 ]
 
 [package.dependencies]
@@ -1669,13 +1669,13 @@ urllib3 = ">=1.25.3,<3.0.0"
 
 [[package]]
 name = "tomlkit"
-version = "0.13.2"
+version = "0.13.3"
 description = "Style preserving TOML library"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde"},
-    {file = "tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"},
+    {file = "tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0"},
+    {file = "tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1"},
 ]
 
 [[package]]
@@ -1913,4 +1913,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "4fe2e97b5c9b9f1c903bb5fa88025eb4ec5b1af460304245aed65f4e4cd9f02e"
+content-hash = "f38af516e4fda9f07cc6d751e152b8f928aa1e2dcb911f5dd56d3cd4fda91dc1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-terra-scientific-pipelines-service-api-client = "1.0.14"
+terra-scientific-pipelines-service-api-client = "1.0.16"
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/terralab/commands/pipelines_commands.py
+++ b/terralab/commands/pipelines_commands.py
@@ -47,7 +47,7 @@ def details(pipeline_name: str, version: int) -> None:
     pipeline_info = pipelines_logic.get_pipeline_info(pipeline_name, version)
 
     # format the information nicely
-    col_width = 18
+    col_width = 20
 
     LOGGER.info(
         f"{pad_column("Pipeline Name:", col_width)}{pipeline_info.pipeline_name}"
@@ -56,6 +56,9 @@ def details(pipeline_name: str, version: int) -> None:
         f"{pad_column("Pipeline Version:", col_width)}{pipeline_info.pipeline_version}"
     )
     LOGGER.info(f"{pad_column("Description:", col_width)}{pipeline_info.description}")
+    LOGGER.info(
+        f"{pad_column("Min Quota Consumed:", col_width)}{pipeline_info.pipeline_quota.min_quota_consumed} {pipeline_info.pipeline_quota.quota_units}"
+    )
     LOGGER.info("Inputs:")
 
     inputs_for_usage = []

--- a/tests/commands/test_pipelines_commands.py
+++ b/tests/commands/test_pipelines_commands.py
@@ -9,6 +9,7 @@ from teaspoons_client import (
     PipelineWithDetails,
     PipelineUserProvidedInputDefinition,
     ApiException,
+    PipelineQuota,
 )
 
 from terralab.commands import pipelines_commands
@@ -54,6 +55,12 @@ def test_get_info_success_no_version(capture_logs, unstub):
     test_input_definition = PipelineUserProvidedInputDefinition(
         name="test_input", type="test_type"
     )
+    test_pipeline_quota = PipelineQuota(
+        pipeline_name="test_pipeline",
+        default_quota=1000,
+        min_quota_consumed=500,
+        quota_units="units",
+    )
     test_pipeline = PipelineWithDetails(
         pipeline_name=test_pipeline_name,
         pipeline_version=1,
@@ -61,6 +68,7 @@ def test_get_info_success_no_version(capture_logs, unstub):
         display_name="test_display_name",
         type="test_type",
         inputs=[test_input_definition],
+        pipeline_quota=test_pipeline_quota,
     )
 
     when(pipelines_commands.pipelines_logic).get_pipeline_info(
@@ -77,9 +85,10 @@ def test_get_info_success_no_version(capture_logs, unstub):
         test_pipeline_name, None
     )
     assert test_pipeline_name in capture_logs.text
-    assert "Pipeline Version: 1" in capture_logs.text
+    assert "Pipeline Version:   1" in capture_logs.text
     assert "test_description" in capture_logs.text
     assert "test_input" in capture_logs.text
+    assert "Min Quota Consumed: 500 units" in capture_logs.text
 
     unstub()
 
@@ -89,6 +98,12 @@ def test_get_info_success_version(capture_logs, unstub):
     test_input_definition = PipelineUserProvidedInputDefinition(
         name="test_input", type="test_type"
     )
+    test_pipeline_quota = PipelineQuota(
+        pipeline_name="test_pipeline",
+        default_quota=1000,
+        min_quota_consumed=500,
+        quota_units="units",
+    )
     test_pipeline = PipelineWithDetails(
         pipeline_name=test_pipeline_name,
         pipeline_version=1,
@@ -96,6 +111,7 @@ def test_get_info_success_version(capture_logs, unstub):
         display_name="test_display_name",
         type="test_type",
         inputs=[test_input_definition],
+        pipeline_quota=test_pipeline_quota,
     )
 
     when(pipelines_commands.pipelines_logic).get_pipeline_info(
@@ -110,9 +126,10 @@ def test_get_info_success_version(capture_logs, unstub):
     assert result.exit_code == 0
     verify(pipelines_commands.pipelines_logic).get_pipeline_info(test_pipeline_name, 1)
     assert test_pipeline_name in capture_logs.text
-    assert "Pipeline Version: 1" in capture_logs.text
+    assert "Pipeline Version:   1" in capture_logs.text
     assert "test_description" in capture_logs.text
     assert "test_input" in capture_logs.text
+    assert "Min Quota Consumed: 500 units" in capture_logs.text
 
     unstub()
 


### PR DESCRIPTION
### Description 

We recently added this info to the service API so we might as well make the data available to the CLI.  Users will want to know the floor of how much quota they will be charged when submitting a pipeline

Before
<img width="1309" alt="Screenshot 2025-06-10 at 11 47 10 AM" src="https://github.com/user-attachments/assets/67082b3f-492a-4cb8-b9d6-ea743a75691a" />

After
<img width="1300" alt="Screenshot 2025-06-10 at 12 25 13 PM" src="https://github.com/user-attachments/assets/bde9d577-3f4a-4152-b955-1efd03c0bf2d" />


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-513

### Checklist (provide links to changes)

- [x] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
