### PR TITLE
TSPS-608 Handle 401 unauthorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file with the fol
 ### Fixed
 - Bug fixes.
 
+## [1.1.1] - 2025-08-02
+
+### Fixed
+- Better handling of 401 Unauthorized errors.
+
 ## [1.1.0] - 2025-09-17
 
 ### Added

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -41,6 +41,13 @@ def handle_api_exceptions(func: Any) -> Any:
                     )
                 )
                 exit(1)
+            elif e.status == 401 and message == "Unauthorized":
+                LOGGER.error(
+                    add_blankline_before(
+                        f"Something went wrong with authorization. Please run 'terralab logout' and then try again.\n{SUPPORT_EMAIL_TEXT}"
+                    )
+                )
+                exit(1)
             formatted_message = (
                 f"API call failed with status code {e.status} ({e.reason}): {message}"
                 if message

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -33,7 +33,12 @@ def handle_api_exceptions(func: Any) -> Any:
                 try:
                     message = json.loads(e.body)["message"]
                 except json.JSONDecodeError:
-                    message = e.body
+                    try:
+                        message = (
+                            e.reason
+                        )  # 401 Unauthorized stores Unauthorized in Reason
+                    except json.JSONDecodeError:
+                        message = e.body
             if e.status == 401 and message == "User not found":
                 LOGGER.error(
                     add_blankline_before(


### PR DESCRIPTION
### Description 

Sometimes tokens go stale or otherwise unusable and Sam returns a 401 Unauthorized message. Here we catch that message and tell the user to logout and try again, rather than showing the unsightly full HTML error message.

Reproducible by authenticating in prod and then trying to run a command against dev:
```
✗ terralab pipelines list        

Something went wrong with authorization. Please run 'terralab logout' and then try again.
For help troubleshooting, email scientific-services-support@broadinstitute.org
```

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-608

### Checklist (provide links to changes)

- [x] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
    3. Auth code flow: run `terralab logout` and then `terralab login` - should prompt a browser login, and copy-paste to CLI should work without an error
    4. Auth code refresh token flow: after step 3, run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
- [x] Updated CHANGELOG.md
