### PR TITLE
TSPS-860 Add outputs (and size) to job details (MINOR rev)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file with the fol
 ## [3.2.0] - 2026-04-10
 
 ### Added
-- The `terralab jobs details` returns pipeline outputs and their file sizes, when available. 
+- The `terralab jobs details` returns pipeline outputs and their file sizes, when available. This change was part of updating the CLI to use the new service API version `api/pipelineruns/v3/result/{jobId}`, as `api/pipelineruns/v2/result/{jobId}` is now deprecated.
 
 ## [3.1.5] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to this project will be documented in this file with the fol
 ### Fixed
 - Bug fixes.
 
+## [3.2.0] - 2026-04-10
+
+### Added
+- The `terralab jobs details` returns pipeline outputs and their file sizes, when available. 
+
 ## [3.1.5] - 2026-03-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file with the fol
 ### Fixed
 - Bug fixes.
 
-## [3.2.0] - 2026-04-10
+## [3.2.0] - 2026-04-13
 
 ### Added
 - The `terralab jobs details` returns pipeline outputs and their file sizes, when available. This change was part of updating the CLI to use the new service API version `api/pipelineruns/v3/result/{jobId}`, as `api/pipelineruns/v2/result/{jobId}` is now deprecated.

--- a/terralab/commands/pipeline_runs_commands.py
+++ b/terralab/commands/pipeline_runs_commands.py
@@ -15,6 +15,7 @@ from terralab.log import (
 )
 from terralab.logic import pipeline_runs_logic, pipelines_logic
 from terralab.utils import (
+    convert_file_size_to_human_readable,
     handle_api_exceptions,
     process_inputs_to_dict,
     validate_job_id,
@@ -141,6 +142,25 @@ def details(job_id: str) -> None:
         LOGGER.info(indented(f"Quota Consumed: {quota_consumed}"))
 
     if response.job_report.status == SUCCEEDED_KEY:
+        if response.pipeline_run_report.outputs:
+            LOGGER.info(indented("Outputs:"))
+            for (
+                output_name,
+                output_value,
+            ) in response.pipeline_run_report.outputs.items():
+                if (
+                    "metadata" in output_value
+                    and "sizeInBytes" in output_value["metadata"]
+                ):
+                    output_size_string = f"({convert_file_size_to_human_readable(output_value['metadata']['sizeInBytes'])})"
+                else:
+                    output_size_string = ""
+                LOGGER.info(
+                    indented(
+                        f"{output_name}: {output_value['value']} {output_size_string}",
+                        n_spaces=4,
+                    )
+                )
         LOGGER.info(
             indented(
                 f"File Download Expiration: {format_timestamp(response.pipeline_run_report.output_expiration_date, timestamp_format)}"

--- a/terralab/commands/pipeline_runs_commands.py
+++ b/terralab/commands/pipeline_runs_commands.py
@@ -1,6 +1,7 @@
 # commands/pipeline_runs_commands.py
 
 import logging
+from typing import Any
 import uuid
 
 import click
@@ -143,27 +144,28 @@ def details(job_id: str) -> None:
 
     if response.job_report.status == SUCCEEDED_KEY:
         if response.pipeline_run_report.outputs:
-            LOGGER.info(indented("Outputs:"))
-            for (
-                output_name,
-                output_value,
-            ) in response.pipeline_run_report.outputs.items():
-                if (
-                    "metadata" in output_value
-                    and "sizeInBytes" in output_value["metadata"]
-                ):
-                    output_size_string = f"({convert_file_size_to_human_readable(output_value['metadata']['sizeInBytes'])})"
-                else:
-                    output_size_string = ""
-                LOGGER.info(
-                    indented(
-                        f"{output_name}: {output_value['value']} {output_size_string}",
-                        n_spaces=4,
-                    )
-                )
+            display_outputs(response.pipeline_run_report.outputs)
         LOGGER.info(
             indented(
                 f"File Download Expiration: {format_timestamp(response.pipeline_run_report.output_expiration_date, timestamp_format)}"
+            )
+        )
+
+
+def display_outputs(outputs: dict[str, dict[str, Any]]) -> None:
+    LOGGER.info(indented("Outputs:"))
+    for (
+        output_name,
+        output_value,
+    ) in outputs.items():
+        if "metadata" in output_value and "sizeInBytes" in output_value["metadata"]:
+            output_size_string = f"({convert_file_size_to_human_readable(output_value['metadata']['sizeInBytes'])})"
+        else:
+            output_size_string = ""
+        LOGGER.info(
+            indented(
+                f"{output_name}: {output_value['value']} {output_size_string}",
+                n_spaces=4,
             )
         )
 

--- a/terralab/commands/pipeline_runs_commands.py
+++ b/terralab/commands/pipeline_runs_commands.py
@@ -143,8 +143,7 @@ def details(job_id: str) -> None:
         LOGGER.info(indented(f"Quota Consumed: {quota_consumed}"))
 
     if response.job_report.status == SUCCEEDED_KEY:
-        if response.pipeline_run_report.outputs:
-            display_outputs(response.pipeline_run_report.outputs)
+        display_outputs(response.pipeline_run_report.outputs)
         LOGGER.info(
             indented(
                 f"File Download Expiration: {format_timestamp(response.pipeline_run_report.output_expiration_date, timestamp_format)}"
@@ -152,7 +151,9 @@ def details(job_id: str) -> None:
         )
 
 
-def display_outputs(outputs: dict[str, dict[str, Any]]) -> None:
+def display_outputs(outputs: dict[str, dict[str, Any]] | None) -> None:
+    if not outputs:
+        return
     LOGGER.info(indented("Outputs:"))
     for (
         output_name,

--- a/terralab/commands/pipeline_runs_commands.py
+++ b/terralab/commands/pipeline_runs_commands.py
@@ -119,7 +119,8 @@ def details(job_id: str) -> None:
 
     LOGGER.info(indented("Inputs:"))
     for input_name, input_value in response.pipeline_run_report.user_inputs.items():
-        LOGGER.info(indented(f"{input_name}: {input_value}", n_spaces=4))
+        LOGGER.info(indented(f"{input_name}:", n_spaces=4))
+        LOGGER.info(indented(input_value, n_spaces=6))
 
     if response.pipeline_run_report.input_size:
         LOGGER.info(
@@ -165,8 +166,14 @@ def display_outputs(outputs: dict[str, dict[str, Any]] | None) -> None:
             output_size_string = ""
         LOGGER.info(
             indented(
-                f"{output_name}: {output_value['value']} {output_size_string}",
+                f"{output_name}:",
                 n_spaces=4,
+            )
+        )
+        LOGGER.info(
+            indented(
+                f"{output_value['value']} {output_size_string}",
+                n_spaces=6,
             )
         )
 

--- a/terralab/logic/pipeline_runs_logic.py
+++ b/terralab/logic/pipeline_runs_logic.py
@@ -82,7 +82,7 @@ def get_pipeline_run_status(job_id: uuid.UUID) -> AsyncPipelineRunResponseV2:
 
     with ClientWrapper() as api_client:
         pipeline_runs_client = PipelineRunsApi(api_client=api_client)
-        return pipeline_runs_client.get_pipeline_run_result_v2(str(job_id))
+        return pipeline_runs_client.get_pipeline_run_result_v3(str(job_id))
 
 
 def get_pipeline_run_output_signed_urls(

--- a/terralab/utils.py
+++ b/terralab/utils.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 import logging
+import math
 import os
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -163,6 +164,17 @@ def validate_file_size(file_path: str) -> str | None:
         file_size_gb = file_size / (1024 * 1024 * 1024)
         return f"Error: File '{file_path}' ({file_size_gb:.2f} GB) exceeds the maximum file size of {max_size_gb:.0f} GB."
     return None
+
+
+def convert_file_size_to_human_readable(size_bytes: int) -> str:
+    """Convert a file size in bytes to a human-readable string with appropriate units."""
+    if size_bytes == 0:
+        return "0 B"
+    size_name = ("B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB")
+    i = int(math.floor(math.log(size_bytes, 1024)))
+    p = math.pow(1024, i)
+    s = round(size_bytes / p, 1) if p > 1 else size_bytes
+    return "%s %s" % (s, size_name[i])
 
 
 ## upload and download methods

--- a/tests/commands/test_pipeline_runs_commands.py
+++ b/tests/commands/test_pipeline_runs_commands.py
@@ -310,7 +310,9 @@ def test_details_succeeded_job(capture_logs, unstub):
     assert "Inputs:" in capture_logs.text
     assert f"{TEST_INPUT_KEY_STRIPPED}: {TEST_INPUT_VALUE}" in capture_logs.text
     assert "Outputs:" in capture_logs.text
-    assert "output1: gs://bucket/path/to/output1 (1.0 MiB)" in capture_logs.text
+    assert (
+        "output1: gs://bucket/path/to/output1 (1.0 MiB)" in capture_logs.text
+    )  # input size is 1048576 bytes
     assert "output2: gs://bucket/path/to/output2" in capture_logs.text
 
     unstub()

--- a/tests/commands/test_pipeline_runs_commands.py
+++ b/tests/commands/test_pipeline_runs_commands.py
@@ -309,6 +309,9 @@ def test_details_succeeded_job(capture_logs, unstub):
     assert f"Input size: {TEST_INPUT_SIZE} {TEST_INPUT_UNIT}" in capture_logs.text
     assert "Inputs:" in capture_logs.text
     assert f"{TEST_INPUT_KEY_STRIPPED}: {TEST_INPUT_VALUE}" in capture_logs.text
+    assert "Outputs:" in capture_logs.text
+    assert "output1: gs://bucket/path/to/output1 (1.0 MiB)" in capture_logs.text
+    assert "output2: gs://bucket/path/to/output2" in capture_logs.text
 
     unstub()
 
@@ -552,6 +555,13 @@ def create_test_pipeline_run_response(
         user_inputs=TEST_INPUTS_DICT,
     )
     if status == SUCCEEDED_KEY:
+        pipeline_run_report.outputs = {
+            "output1": {
+                "value": "gs://bucket/path/to/output1",
+                "metadata": {"sizeInBytes": 1048576},
+            },
+            "output2": {"value": "gs://bucket/path/to/output2"},
+        }
         pipeline_run_report.quota_consumed = TEST_QUOTA_CONSUMED
 
     if include_input_size:

--- a/tests/commands/test_pipeline_runs_commands.py
+++ b/tests/commands/test_pipeline_runs_commands.py
@@ -209,12 +209,10 @@ def test_details_running_job(capture_logs, unstub):
     assert "Completed:" not in capture_logs.text
     assert f"Input size: {TEST_INPUT_SIZE} {TEST_INPUT_UNIT}" in capture_logs.text
     assert "Inputs:" in capture_logs.text
-    assert f"{TEST_INPUT_KEY_STRIPPED}: {TEST_INPUT_VALUE}" in capture_logs.text
-    assert (
-        f"{OPTIONAL_INPUT_NAME}: {user_defined_optional_input_value}"
-        in capture_logs.text
-    )
-
+    assert f"{TEST_INPUT_KEY_STRIPPED}:" in capture_logs.text
+    assert TEST_INPUT_VALUE in capture_logs.text
+    assert f"{OPTIONAL_INPUT_NAME}:" in capture_logs.text
+    assert user_defined_optional_input_value in capture_logs.text
     unstub()
 
 
@@ -244,7 +242,8 @@ def test_details_running_job_with_input_size(capture_logs, unstub):
     assert "Completed:" not in capture_logs.text
     assert f"Input size: {TEST_INPUT_SIZE} {TEST_INPUT_UNIT}" in capture_logs.text
     assert "Inputs:" in capture_logs.text
-    assert f"{TEST_INPUT_KEY_STRIPPED}: {TEST_INPUT_VALUE}" in capture_logs.text
+    assert f"{TEST_INPUT_KEY_STRIPPED}:" in capture_logs.text
+    assert TEST_INPUT_VALUE in capture_logs.text
 
     unstub()
 
@@ -275,7 +274,8 @@ def test_details_running_job_without_input_size(capture_logs, unstub):
     assert "Completed:" not in capture_logs.text
     assert f"Input size: {TEST_INPUT_SIZE} {TEST_INPUT_UNIT}" not in capture_logs.text
     assert "Inputs:" in capture_logs.text
-    assert f"{TEST_INPUT_KEY_STRIPPED}: {TEST_INPUT_VALUE}" in capture_logs.text
+    assert f"{TEST_INPUT_KEY_STRIPPED}:" in capture_logs.text
+    assert TEST_INPUT_VALUE in capture_logs.text
 
     unstub()
 
@@ -308,12 +308,15 @@ def test_details_succeeded_job(capture_logs, unstub):
     assert f"Quota Consumed: {TEST_QUOTA_CONSUMED}" in capture_logs.text
     assert f"Input size: {TEST_INPUT_SIZE} {TEST_INPUT_UNIT}" in capture_logs.text
     assert "Inputs:" in capture_logs.text
-    assert f"{TEST_INPUT_KEY_STRIPPED}: {TEST_INPUT_VALUE}" in capture_logs.text
+    assert f"{TEST_INPUT_KEY_STRIPPED}:" in capture_logs.text
+    assert TEST_INPUT_VALUE in capture_logs.text
     assert "Outputs:" in capture_logs.text
+    assert "output1:" in capture_logs.text
     assert (
-        "output1: gs://bucket/path/to/output1 (1.0 MiB)" in capture_logs.text
+        "gs://bucket/path/to/output1 (1.0 MiB)" in capture_logs.text
     )  # input size is 1048576 bytes
-    assert "output2: gs://bucket/path/to/output2" in capture_logs.text
+    assert "output2:" in capture_logs.text
+    assert "gs://bucket/path/to/output2" in capture_logs.text
 
     unstub()
 
@@ -349,7 +352,8 @@ def test_details_failed_job_with_input_size(capture_logs, unstub):
     assert "Quota Consumed: 0" in capture_logs.text
     assert f"Input size: {TEST_INPUT_SIZE} {TEST_INPUT_UNIT}" in capture_logs.text
     assert "Inputs:" in capture_logs.text
-    assert f"{TEST_INPUT_KEY_STRIPPED}: {TEST_INPUT_VALUE}" in capture_logs.text
+    assert f"{TEST_INPUT_KEY_STRIPPED}:" in capture_logs.text
+    assert TEST_INPUT_VALUE in capture_logs.text
 
     unstub()
 
@@ -385,7 +389,8 @@ def test_details_failed_job_without_input_size(capture_logs, unstub):
     assert "Quota Consumed: 0" in capture_logs.text
     assert f"Input size: {TEST_INPUT_SIZE} {TEST_INPUT_UNIT}" not in capture_logs.text
     assert "Inputs:" in capture_logs.text
-    assert f"{TEST_INPUT_KEY_STRIPPED}: {TEST_INPUT_VALUE}" in capture_logs.text
+    assert f"{TEST_INPUT_KEY_STRIPPED}:" in capture_logs.text
+    assert TEST_INPUT_VALUE in capture_logs.text
 
     unstub()
 

--- a/tests/logic/test_pipeline_runs_logic.py
+++ b/tests/logic/test_pipeline_runs_logic.py
@@ -289,14 +289,14 @@ def test_get_pipeline_run_status(mock_pipeline_runs_api):
     mock_job_report = mock({"id": test_job_id})
     mock_async_pipeline_run_response = mock({"job_report": mock_job_report})
 
-    when(mock_pipeline_runs_api).get_pipeline_run_result_v2(test_job_id_str).thenReturn(
+    when(mock_pipeline_runs_api).get_pipeline_run_result_v3(test_job_id_str).thenReturn(
         mock_async_pipeline_run_response
     )
 
     response = pipeline_runs_logic.get_pipeline_run_status(test_job_id)
 
     assert response == mock_async_pipeline_run_response
-    verify(mock_pipeline_runs_api).get_pipeline_run_result_v2(test_job_id_str)
+    verify(mock_pipeline_runs_api).get_pipeline_run_result_v3(test_job_id_str)
 
 
 def test_get_pipeline_run_output_signed_urls(mock_pipeline_runs_api):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -127,6 +127,16 @@ def test_validate_file_size_exceeds_limit():
         assert test_file_path in result
 
 
+def test_convert_file_size_to_human_readable():
+    assert utils.convert_file_size_to_human_readable(0) == "0 B"
+    assert utils.convert_file_size_to_human_readable(500) == "500 B"
+    assert utils.convert_file_size_to_human_readable(1024) == "1.0 KiB"
+    assert utils.convert_file_size_to_human_readable(1536) == "1.5 KiB"
+    assert utils.convert_file_size_to_human_readable(1048576) == "1.0 MiB"
+    assert utils.convert_file_size_to_human_readable(1073741824) == "1.0 GiB"
+    assert utils.convert_file_size_to_human_readable(1099511627776) == "1.0 TiB"
+
+
 def test_upload_file_with_signed_url_success(capture_logs):
     test_signed_url = "signed_url"
 


### PR DESCRIPTION
### Description 

Add outputs to `terralab jobs details` response, including human-readable file size info if available.

response before:
```
✗ terralab jobs details 21883e29-a565-4b1a-bc11-e14c5628dd90
Status: Succeeded

Details:
  Pipeline Name: array_imputation
  Pipeline Version: 2
  Description: test new v3 output format
  Inputs:
    multiSampleVcf: /Users/marymorg/Desktop/gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20.vcf.gz
    outputBasename: gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20
    minDr2ForInclusion: .8
  Input size: 500 samples
  Submitted: 2026-04-08 13:38 EDT
  Completed: 2026-04-08 15:40 EDT
  Quota Consumed: 500
  File Download Expiration: 2026-04-22 15:40 EDT
```

response after
```
✗ terralab jobs details 21883e29-a565-4b1a-bc11-e14c5628dd90

Status: Succeeded

Details:
  Pipeline Name: array_imputation
  Pipeline Version: 2
  Description: test new v3 output format
  Inputs:
    multiSampleVcf:
      /Users/marymorg/Desktop/gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20.vcf.gz
    outputBasename:
      gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20
    minDr2ForInclusion:
      .8
  Input size: 500 samples
  Submitted: 2026-04-08 13:38 EDT
  Completed: 2026-04-08 15:40 EDT
  Quota Consumed: 500
  Outputs:
    imputedMultiSampleVcfIndex:
      gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20.imputed.vcf.gz.tbi (49.6 KiB)
    imputedHomRefSitesOnlyVcf:
      gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20.imputed.hom_ref_sites_only.vcf.gz (19.4 KiB)
    imputedHomRefSitesOnlyVcfIndex:
      gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20.imputed.hom_ref_sites_only.vcf.gz.tbi (80 B)
    contigsInfo:
      gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20_contig_info.tsv (144 B)
    imputedMultiSampleVcf:
      gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20.imputed.vcf.gz (75.0 MiB)
    chunksInfo:
      gnomad.genomes.v3.1.2.hgdp_tgp.500samples.chr20_chunk_info.tsv (182 B)
  File Download Expiration: 2026-04-22 15:40 EDT
```

### Jira Ticket


### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
    3. Auth code flow: run `terralab logout` and then `terralab login` - should prompt a browser login, and copy-paste to CLI should work without an error
    4. Auth code refresh token flow: after step 3, run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [x] Planned non patch version bump : plan MINOR rev
- [ ] Updated Teaspoons PR (if applicable)
- [x] Updated CHANGELOG.md
