### PR TITLE
TSPS-742  update default version for e2e tests to 2

### DIFF
--- a/.github/workflows/run-bee-e2e-tests.yml
+++ b/.github/workflows/run-bee-e2e-tests.yml
@@ -157,7 +157,7 @@ jobs:
           workflow: teaspoons-bee-e2e-cli-test
           run-name: "teaspoons-bee-e2e-cli-test-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/js_TSPS-742
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           inputs: '{ 

--- a/.github/workflows/run-bee-e2e-tests.yml
+++ b/.github/workflows/run-bee-e2e-tests.yml
@@ -50,8 +50,8 @@ on:
           - staging
           - prod
       pipeline-version:
-        description: 'version of the pipeline to run. default to 1.'
-        default: '1'
+        description: 'version of the pipeline to run. default to 2.'
+        default: '2'
         required: true
         type: string
 
@@ -157,7 +157,7 @@ jobs:
           workflow: teaspoons-bee-e2e-cli-test
           run-name: "teaspoons-bee-e2e-cli-test-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/js_TSPS-742
+          ref: refs/heads/main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           inputs: '{ 

--- a/.github/workflows/run-live-env-e2e-tests.yml
+++ b/.github/workflows/run-live-env-e2e-tests.yml
@@ -25,7 +25,7 @@ on:
         default: 'NA12878_10_samples_chr1_chr20.vcf.gz' # small VCF file with 10 samples, chr1 and chr20 data only
         type: string
       use-cloud-input:
-        description: 'Whether to use a cloud input file or a local file for the test. Default true.'
+        description: 'Whether to use a cloud input file (true_ or a local file (false) for the test. Default true.'
         required: true
         default: 'true'
         type: string

--- a/.github/workflows/run-live-env-e2e-tests.yml
+++ b/.github/workflows/run-live-env-e2e-tests.yml
@@ -25,7 +25,7 @@ on:
         default: 'NA12878_10_samples_chr1_chr20.vcf.gz' # small VCF file with 10 samples, chr1 and chr20 data only
         type: string
       use-cloud-input:
-        description: 'Whether to use a cloud input file (true_ or a local file (false) for the test. Default true.'
+        description: 'Whether to use a cloud input file (true) or a local file (false) for the test. Default true.'
         required: true
         default: 'true'
         type: string

--- a/.github/workflows/run-live-env-e2e-tests.yml
+++ b/.github/workflows/run-live-env-e2e-tests.yml
@@ -30,8 +30,8 @@ on:
         default: 'true'
         type: string
       pipeline-version:
-        description: 'version of the pipeline to run. default to 1.'
-        default: '1'
+        description: 'version of the pipeline to run. default to 2.'
+        default: '2'
         required: true
         type: string
 


### PR DESCRIPTION
### Description 

Now that we are releasing v2 of the array imputatino pipeline, we should be testing that by default.  This goes with https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/334 and https://github.com/broadinstitute/terra-github-workflows/pull/249

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-742


### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
    3. Auth code flow: run `terralab logout` and then `terralab login` - should prompt a browser login, and copy-paste to CLI should work without an error
    4. Auth code refresh token flow: after step 3, run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
- [ ] Updated CHANGELOG.md
