### PR TITLE
TSPS-829 Add low pass imputation e2e test for live env

### DIFF
--- a/.github/workflows/run-live-env-e2e-tests.yml
+++ b/.github/workflows/run-live-env-e2e-tests.yml
@@ -19,21 +19,6 @@ on:
         options:
           - dev
           - staging
-      input-vcf-file-name:
-        description: 'Name of the input VCF file to use in the test (just the file name and not the entire path)'
-        required: true
-        default: 'NA12878_10_samples_chr1_chr20.vcf.gz' # small VCF file with 10 samples, chr1 and chr20 data only
-        type: string
-      use-cloud-input:
-        description: 'Whether to use a cloud input file (true) or a local file (false) for the test. Default true.'
-        required: true
-        default: 'true'
-        type: string
-      pipeline-version:
-        description: 'version of the pipeline to run. default to 2.'
-        default: '2'
-        required: true
-        type: string
 
 jobs:
   init-github-context-and-params-gen:
@@ -56,7 +41,7 @@ jobs:
             echo "cli-version-ref=${{ inputs.cli-version-ref }}" >> $GITHUB_OUTPUT
           fi
 
-  run-live-env-e2e-test-job:
+  run-live-env-e2e-test-job-array-imputation-v2-cloud-inputs:
     runs-on: ubuntu-latest
     needs: [ init-github-context-and-params-gen ]
     permissions:
@@ -67,20 +52,101 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4.0.1
         with:
           workflow: teaspoons-live-env-e2e-cli-test
-          run-name: "teaspoons-live-env-e2e-cli-test-${{ github.run_id }}-${{ github.run_attempt }}"
+          run-name: "teaspoons-live-env-e2e-cli-test-array-imputation-v2-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
-              "run-name": "teaspoons-live-env-e2e-cli-test-${{ github.run_id }}-${{ github.run_attempt }}",
+              "run-name": "teaspoons-live-env-e2e-cli-test-array-imputation-v2-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
               "e2e-test-version-ref": "${{ inputs.e2e-test-version-ref }}",
               "cli-version-ref": "${{ needs.init-github-context-and-params-gen.outputs.cli-version-ref }}",
               "env-name": "${{inputs.env-name}}",
-              "input-vcf-file-name": "${{inputs.input-vcf-file-name}}",
-              "use-cloud-input": "${{inputs.use-cloud-input}}",
-              "pipeline-version": "${{ inputs.pipeline-version }}"
+              "pipeline-name": "array_imputation",
+              "pipeline-version": "2",
+              "use-cloud-input": "true"
+            }'
+
+  run-live-env-e2e-test-job-array-imputation-v2-local-inputs:
+    runs-on: ubuntu-latest
+    needs: [ init-github-context-and-params-gen ]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Dispatch to terra-github-workflows to run e2e test
+        uses: broadinstitute/workflow-dispatch@v4.0.1
+        with:
+          workflow: teaspoons-live-env-e2e-cli-test
+          run-name: "teaspoons-live-env-e2e-cli-test-array-imputation-v2-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          wait-for-completion: true
+          token: '${{ secrets.BROADBOT_TOKEN }}'
+          wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
+          inputs: '{
+              "run-name": "teaspoons-live-env-e2e-cli-test-array-imputation-v2-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
+              "e2e-test-version-ref": "${{ inputs.e2e-test-version-ref }}",
+              "cli-version-ref": "${{ needs.init-github-context-and-params-gen.outputs.cli-version-ref }}",
+              "env-name": "${{inputs.env-name}}",
+              "pipeline-name": "array_imputation",
+              "pipeline-version": "2",
+              "use-cloud-input": "false"
+            }'
+
+  run-live-env-e2e-test-job-low-pass-imputation-v1-cloud-inputs:
+    runs-on: ubuntu-latest
+    needs: [ init-github-context-and-params-gen ]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Dispatch to terra-github-workflows to run e2e test
+        uses: broadinstitute/workflow-dispatch@v4.0.1
+        with:
+          workflow: teaspoons-live-env-e2e-cli-test
+          run-name: "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          wait-for-completion: true
+          token: '${{ secrets.BROADBOT_TOKEN }}'
+          wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
+          inputs: '{
+              "run-name": "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
+              "e2e-test-version-ref": "${{ inputs.e2e-test-version-ref }}",
+              "cli-version-ref": "${{ needs.init-github-context-and-params-gen.outputs.cli-version-ref }}",
+              "env-name": "${{inputs.env-name}}",
+              "pipeline-name": "low_pass_imputation",
+              "pipeline-version": "1",
+              "use-cloud-input": "true"
+            }'
+
+  run-live-env-e2e-test-job-low-pass-imputation-v1-local-inputs:
+    runs-on: ubuntu-latest
+    needs: [ init-github-context-and-params-gen ]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Dispatch to terra-github-workflows to run e2e test
+        uses: broadinstitute/workflow-dispatch@v4.0.1
+        with:
+          workflow: teaspoons-live-env-e2e-cli-test
+          run-name: "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
+          repo: broadinstitute/terra-github-workflows
+          ref: refs/heads/main
+          wait-for-completion: true
+          token: '${{ secrets.BROADBOT_TOKEN }}'
+          wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
+          inputs: '{
+              "run-name": "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
+              "e2e-test-version-ref": "${{ inputs.e2e-test-version-ref }}",
+              "cli-version-ref": "${{ needs.init-github-context-and-params-gen.outputs.cli-version-ref }}",
+              "env-name": "${{inputs.env-name}}",
+              "pipeline-name": "low_pass_imputation",
+              "pipeline-version": "1",
+              "use-cloud-input": "false"
             }'
 
   report-workflow:

--- a/.github/workflows/run-live-env-e2e-tests.yml
+++ b/.github/workflows/run-live-env-e2e-tests.yml
@@ -54,7 +54,7 @@ jobs:
           workflow: teaspoons-live-env-e2e-cli-test
           run-name: "teaspoons-live-env-e2e-cli-test-array-imputation-v2-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
@@ -81,7 +81,7 @@ jobs:
           workflow: teaspoons-live-env-e2e-cli-test
           run-name: "teaspoons-live-env-e2e-cli-test-array-imputation-v2-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
@@ -108,7 +108,7 @@ jobs:
           workflow: teaspoons-live-env-e2e-cli-test
           run-name: "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
@@ -135,7 +135,7 @@ jobs:
           workflow: teaspoons-live-env-e2e-cli-test
           run-name: "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/main
+          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete

--- a/.github/workflows/run-live-env-e2e-tests.yml
+++ b/.github/workflows/run-live-env-e2e-tests.yml
@@ -52,14 +52,14 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4.0.1
         with:
           workflow: teaspoons-live-env-e2e-cli-test
-          run-name: "teaspoons-live-env-e2e-cli-test-array-imputation-v2-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
+          run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-array-imputation-v2-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
-              "run-name": "teaspoons-live-env-e2e-cli-test-array-imputation-v2-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
+              "run-name": "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-array-imputation-v2-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
               "e2e-test-version-ref": "${{ inputs.e2e-test-version-ref }}",
               "cli-version-ref": "${{ needs.init-github-context-and-params-gen.outputs.cli-version-ref }}",
               "env-name": "${{inputs.env-name}}",
@@ -79,14 +79,14 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4.0.1
         with:
           workflow: teaspoons-live-env-e2e-cli-test
-          run-name: "teaspoons-live-env-e2e-cli-test-array-imputation-v2-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
+          run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-array-imputation-v2-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
-              "run-name": "teaspoons-live-env-e2e-cli-test-array-imputation-v2-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
+              "run-name": "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-array-imputation-v2-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
               "e2e-test-version-ref": "${{ inputs.e2e-test-version-ref }}",
               "cli-version-ref": "${{ needs.init-github-context-and-params-gen.outputs.cli-version-ref }}",
               "env-name": "${{inputs.env-name}}",
@@ -106,14 +106,14 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4.0.1
         with:
           workflow: teaspoons-live-env-e2e-cli-test
-          run-name: "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
+          run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-low-pass-imputation-v1-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
-              "run-name": "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
+              "run-name": "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-low-pass-imputation-v1-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
               "e2e-test-version-ref": "${{ inputs.e2e-test-version-ref }}",
               "cli-version-ref": "${{ needs.init-github-context-and-params-gen.outputs.cli-version-ref }}",
               "env-name": "${{inputs.env-name}}",
@@ -133,14 +133,14 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4.0.1
         with:
           workflow: teaspoons-live-env-e2e-cli-test
-          run-name: "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
+          run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-low-pass-imputation-v1-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
           inputs: '{
-              "run-name": "teaspoons-live-env-e2e-cli-test-low-pass-imputation-v1-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
+              "run-name": "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-low-pass-imputation-v1-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}",
               "e2e-test-version-ref": "${{ inputs.e2e-test-version-ref }}",
               "cli-version-ref": "${{ needs.init-github-context-and-params-gen.outputs.cli-version-ref }}",
               "env-name": "${{inputs.env-name}}",

--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,19 +1,20 @@
 # Teaspoons service API URL
-TEASPOONS_API_URL=https://teaspoons.dsde-prod.broadinstitute.org
+TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
+# TEASPOONS_API_URL=http://localhost:8080
 
 # Sam service API URL
-SAM_API_URL=https://sam.dsde-prod.broadinstitute.org
+SAM_API_URL=https://sam.dsde-dev.broadinstitute.org
 
 # Port to use for local server (for auth)
 SERVER_PORT=10444
 
 # B2C auth config
-OAUTH_OPENID_CONFIGURATION_URI=https://terraprodb2c.b2clogin.com/terraprodb2c.onmicrosoft.com/b2c_1a_signup_signin_tsps_prod/v2.0/.well-known/openid-configuration
-OAUTH_CLIENT_ID=4aefc4ac-d5be-4440-ae9a-aefe4ceb098c
-REMOTE_OAUTH_REDIRECT_URI=https://services.terra.bio/pipelines/cli-auth
+OAUTH_OPENID_CONFIGURATION_URI=https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin_dev/v2.0/.well-known/openid-configuration
+OAUTH_CLIENT_ID=bbd07d43-01cb-4b69-8fd0-5746d9a5c9fe
+REMOTE_OAUTH_REDIRECT_URI=https://bvdp-saturn-dev.appspot.com/pipelines/cli-auth
 
 # Terralab storage (absolute path or relative to user's home directory)
-LOCAL_STORAGE_PATH=.terralab
+LOCAL_STORAGE_PATH=.terralab-dev
 
 # Teaspoons service share-group (for cloud integration)
 TEASPOONS_SHARE_GROUP=broad-scientific-services@firecloud.org

--- a/terralab/.terralab-cli-config
+++ b/terralab/.terralab-cli-config
@@ -1,20 +1,19 @@
 # Teaspoons service API URL
-TEASPOONS_API_URL=https://teaspoons.dsde-dev.broadinstitute.org
-# TEASPOONS_API_URL=http://localhost:8080
+TEASPOONS_API_URL=https://teaspoons.dsde-prod.broadinstitute.org
 
 # Sam service API URL
-SAM_API_URL=https://sam.dsde-dev.broadinstitute.org
+SAM_API_URL=https://sam.dsde-prod.broadinstitute.org
 
 # Port to use for local server (for auth)
 SERVER_PORT=10444
 
 # B2C auth config
-OAUTH_OPENID_CONFIGURATION_URI=https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin_dev/v2.0/.well-known/openid-configuration
-OAUTH_CLIENT_ID=bbd07d43-01cb-4b69-8fd0-5746d9a5c9fe
-REMOTE_OAUTH_REDIRECT_URI=https://bvdp-saturn-dev.appspot.com/pipelines/cli-auth
+OAUTH_OPENID_CONFIGURATION_URI=https://terraprodb2c.b2clogin.com/terraprodb2c.onmicrosoft.com/b2c_1a_signup_signin_tsps_prod/v2.0/.well-known/openid-configuration
+OAUTH_CLIENT_ID=4aefc4ac-d5be-4440-ae9a-aefe4ceb098c
+REMOTE_OAUTH_REDIRECT_URI=https://services.terra.bio/pipelines/cli-auth
 
 # Terralab storage (absolute path or relative to user's home directory)
-LOCAL_STORAGE_PATH=.terralab-dev
+LOCAL_STORAGE_PATH=.terralab
 
 # Teaspoons service share-group (for cloud integration)
 TEASPOONS_SHARE_GROUP=broad-scientific-services@firecloud.org


### PR DESCRIPTION
### Description 

Adapted e2e live env test to use pipeline-agnostic workflow, to now kick off the following tests:
- array_imputation v2 cloud inputs
- array_imputation v2 local inputs
- low_pass_imputation v1 cloud inputs - duration ~1 hour with call caching up to GlimpsePhase
- low_pass_imputation v1 local inputs
  - note the current version of teaspoons fails on this because of a bug that will be [fixed in TSPS-912](https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/397/changes#r3344637119)

terra-github-workflows PR: https://github.com/broadinstitute/terra-github-workflows/pull/257

test run: https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/actions/runs/27038124702/

GHA view in this repo:
<img width="1080" height="682" alt="image" src="https://github.com/user-attachments/assets/ed64e994-7868-43f4-9b0e-aa16b855d7a9" />

Inside a single pipeline workflow:
<img width="918" height="692" alt="image" src="https://github.com/user-attachments/assets/b189eccd-c219-42ed-be9c-72106a4108e6" />

GHA view in terra-github-workflows repo:
<img width="1034" height="540" alt="image" src="https://github.com/user-attachments/assets/251c9209-50c6-4501-8222-1f34d4b1d8a7" />


### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-829

### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
    3. Auth code flow: run `terralab logout` and then `terralab login` - should prompt a browser login, and copy-paste to CLI should work without an error
    4. Auth code refresh token flow: after step 3, run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
- [ ] Updated CHANGELOG.md
