### PR TITLE
TSPS-829 fix: correct ref

### DIFF
--- a/.github/workflows/run-live-env-e2e-tests.yml
+++ b/.github/workflows/run-live-env-e2e-tests.yml
@@ -54,7 +54,7 @@ jobs:
           workflow: teaspoons-live-env-e2e-cli-test
           run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-array-imputation-v2-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
+          ref: refs/heads/main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
@@ -81,7 +81,7 @@ jobs:
           workflow: teaspoons-live-env-e2e-cli-test
           run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-array-imputation-v2-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
+          ref: refs/heads/main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
@@ -108,7 +108,7 @@ jobs:
           workflow: teaspoons-live-env-e2e-cli-test
           run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-low-pass-imputation-v1-cloud-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
+          ref: refs/heads/main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete
@@ -135,7 +135,7 @@ jobs:
           workflow: teaspoons-live-env-e2e-cli-test
           run-name: "teaspoons-${{inputs.env-name}}-live-env-e2e-cli-test-low-pass-imputation-v1-local-inputs-${{ github.run_id }}-${{ github.run_attempt }}"
           repo: broadinstitute/terra-github-workflows
-          ref: refs/heads/TSPS-829_e2e_tests_add_low_pass_pipeline # TODO revert to main
+          ref: refs/heads/main
           wait-for-completion: true
           token: '${{ secrets.BROADBOT_TOKEN }}'
           wait-for-completion-timeout: 2h # default timeout is 1 hour, but this e2e test can sometimes take around 1.5 hours to complete


### PR DESCRIPTION
### Description 

Forgot to point the tests back to main instead of the feature branch in terra-github-workflows in https://github.com/DataBiosphere/terra-scientific-pipelines-service-cli/pull/109

### Jira Ticket
https://broadworkbench.atlassian.net/browse/TSPS-829

### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
    3. Auth code flow: run `terralab logout` and then `terralab login` - should prompt a browser login, and copy-paste to CLI should work without an error
    4. Auth code refresh token flow: after step 3, run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
- [ ] Updated CHANGELOG.md
