### PR TITLE
[TSPS-971] Add link to quotas documentation in `quota` command

### DIFF
--- a/terralab/commands/quotas_commands.py
+++ b/terralab/commands/quotas_commands.py
@@ -4,7 +4,7 @@ import logging
 
 import click
 
-from terralab.log import indented
+from terralab.log import indented, add_blankline_before
 from terralab.logic import quotas_logic
 from terralab.utils import handle_api_exceptions
 
@@ -30,4 +30,10 @@ def quota(pipeline_name: str) -> None:
     LOGGER.info(indented(f"Quota Used: {quota_consumed} {quota_units}"))
     LOGGER.info(
         indented(f"Quota Available: {quota_limit - quota_consumed} {quota_units}")
+    )
+    LOGGER.info(
+        add_blankline_before(
+            "For more information on quotas and how to request more, visit: "
+            "https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035"
+        )
     )

--- a/terralab/commands/quotas_commands.py
+++ b/terralab/commands/quotas_commands.py
@@ -33,7 +33,7 @@ def quota(pipeline_name: str) -> None:
     )
     LOGGER.info(
         add_blankline_before(
-            "For more information on quotas and how to request more, visit: "
+            "For more information on quotas and how to purchase more, visit: "
             "https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035"
         )
     )

--- a/terralab/commands/quotas_commands.py
+++ b/terralab/commands/quotas_commands.py
@@ -6,6 +6,7 @@ import click
 
 from terralab.log import indented, add_blankline_before
 from terralab.logic import quotas_logic
+from terralab.constants import QUOTAS_SUPPORT_ARTICLE_URL
 from terralab.utils import handle_api_exceptions
 
 LOGGER = logging.getLogger(__name__)
@@ -34,6 +35,6 @@ def quota(pipeline_name: str) -> None:
     LOGGER.info(
         add_blankline_before(
             "For more information on quotas and how to purchase more, visit: "
-            "https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035"
+            f"{QUOTAS_SUPPORT_ARTICLE_URL}"
         )
     )

--- a/terralab/constants.py
+++ b/terralab/constants.py
@@ -21,3 +21,6 @@ MAX_FILE_UPLOAD_SIZE_BYTES = 50 * 1025 * 1024 * 1024  # 50GB
 SUPPORT_EMAIL = "scientific-services-support@broadinstitute.org"
 SUPPORT_EMAIL_TEXT = f"For help troubleshooting, email {SUPPORT_EMAIL}"
 TERMS_OF_SERVICE_URL = "https://services.terra.bio/#pipelines/terms-of-service"
+QUOTAS_SUPPORT_ARTICLE_URL = (
+    "https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035"
+)

--- a/tests/commands/test_quotas_commands.py
+++ b/tests/commands/test_quotas_commands.py
@@ -37,6 +37,11 @@ def test_get_info_success(capture_logs, unstub):
     assert "Quota Used: 300 samples" in capture_logs.text
     # quota left
     assert "Quota Available: 700 samples" in capture_logs.text
+    # quotas article link
+    assert (
+        "https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035"
+        in capture_logs.text
+    )
 
     unstub()
 


### PR DESCRIPTION
### Description 

Example output:

```
$ terralab quota array_imputation
Note: It may take a few minutes for recently submitted jobs to be reflected.
Pipeline: array_imputation
  Quota Limit: 30000 samples
  Quota Used: 2500 samples
  Quota Available: 27500 samples

For more information on quotas and how to purchase more, visit: https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035
```

### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-971


### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
    3. Auth code flow: run `terralab logout` and then `terralab login` - should prompt a browser login, and copy-paste to CLI should work without an error
    4. Auth code refresh token flow: after step 3, run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
- [ ] Updated CHANGELOG.md
