### PR TITLE
[TSPS-974] Show max quota in pipeline details

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2292,14 +2292,14 @@ widechars = ["wcwidth"]
 
 [[package]]
 name = "terra-scientific-pipelines-service-api-client"
-version = "6.0.1"
+version = "6.0.6"
 description = "Terra Scientific Pipelines Service"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "terra_scientific_pipelines_service_api_client-6.0.1-py3-none-any.whl", hash = "sha256:e1e7f22332ed746412b64e04d4f51dfd5942f6035962b7f23cddb42faf3cb21c"},
-    {file = "terra_scientific_pipelines_service_api_client-6.0.1.tar.gz", hash = "sha256:7f8c40740d762a0f1b3be28efdbd95505e62b3c381a45bc461ec7b116f8cad48"},
+    {file = "terra_scientific_pipelines_service_api_client-6.0.6-py3-none-any.whl", hash = "sha256:ee73254ae6b67ce63e262355e6e3abfc38d316d319161c846816d63a5ccfc1a9"},
+    {file = "terra_scientific_pipelines_service_api_client-6.0.6.tar.gz", hash = "sha256:f09ddc494866d49de80f2a19f9d7224d25180eddc48ed9a51e9a26410f4de0c2"},
 ]
 
 [package.dependencies]
@@ -2557,4 +2557,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "e60295199b87d8d4139e20a25c8bec2c2369bd3f72874b8007aef3cfe0753916"
+content-hash = "ded0c4ea44b86a88ac9420ddc32cfdca1c06096e4a88eeaa6fe5b53da883a415"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ terralab = "terralab.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.12"
-terra-scientific-pipelines-service-api-client = "6.0.1"
+terra-scientific-pipelines-service-api-client = "6.0.6"
 python-dotenv = "^1.0.1"
 click = "^8.1.7"
 colorlog = "^6.9.0"

--- a/terralab/commands/pipelines_commands.py
+++ b/terralab/commands/pipelines_commands.py
@@ -62,7 +62,7 @@ def details(pipeline_name: str, version: int) -> None:
             "",
         ],
         [
-            "Max Quota Consumed",
+            f"Max {pipeline_info.pipeline_quota.quota_units.capitalize()} Allowed Per Job",
             f"{pipeline_info.pipeline_quota.max_quota_consumed} {pipeline_info.pipeline_quota.quota_units.lower()}",
             "",
         ],

--- a/terralab/commands/pipelines_commands.py
+++ b/terralab/commands/pipelines_commands.py
@@ -61,6 +61,11 @@ def details(pipeline_name: str, version: int) -> None:
             f"{pipeline_info.pipeline_quota.min_quota_consumed} {pipeline_info.pipeline_quota.quota_units.lower()}",
             "",
         ],
+        [
+            "Max Quota Consumed",
+            f"{pipeline_info.pipeline_quota.max_quota_consumed} {pipeline_info.pipeline_quota.quota_units.lower()}",
+            "",
+        ],
     ]
     LOGGER.info(format_table_no_header(pipeline_info_rows))
 

--- a/tests/commands/test_pipelines_commands.py
+++ b/tests/commands/test_pipelines_commands.py
@@ -101,12 +101,12 @@ def test_get_info_success_no_version(capture_logs):
         test_pipeline_name, None
     )
     assert test_pipeline_name in capture_logs.text
-    assert "Version             1" in capture_logs.text
+    assert "Version                    1" in capture_logs.text
     assert "test_description" in capture_logs.text
     assert "test_input" in capture_logs.text
     assert "test_output" in capture_logs.text
-    assert "Min Quota Consumed  500 units" in capture_logs.text
-    assert "Max Quota Consumed  5000 units" in capture_logs.text
+    assert "Min Quota Consumed         500 units" in capture_logs.text
+    assert "Max Units Allowed Per Job  5000 units" in capture_logs.text
     assert "test input description" in capture_logs.text
     assert "test output description" in capture_logs.text
 
@@ -156,12 +156,12 @@ def test_get_info_success_version(capture_logs):
     assert result.exit_code == 0
     verify(pipelines_commands.pipelines_logic).get_pipeline_info(test_pipeline_name, 1)
     assert test_pipeline_name in capture_logs.text
-    assert "Version             1" in capture_logs.text
+    assert "Version                    1" in capture_logs.text
     assert "test_description" in capture_logs.text
     assert "test_input" in capture_logs.text
     assert "test_output" in capture_logs.text
-    assert "Min Quota Consumed  500 units" in capture_logs.text
-    assert "Max Quota Consumed  5000 units" in capture_logs.text
+    assert "Min Quota Consumed         500 units" in capture_logs.text
+    assert "Max Units Allowed Per Job  5000 units" in capture_logs.text
     assert "test input description" in capture_logs.text
     assert "test output description" in capture_logs.text
 

--- a/tests/commands/test_pipelines_commands.py
+++ b/tests/commands/test_pipelines_commands.py
@@ -106,6 +106,7 @@ def test_get_info_success_no_version(capture_logs):
     assert "test_input" in capture_logs.text
     assert "test_output" in capture_logs.text
     assert "Min Quota Consumed  500 units" in capture_logs.text
+    assert "Max Quota Consumed  5000 units" in capture_logs.text
     assert "test input description" in capture_logs.text
     assert "test output description" in capture_logs.text
 
@@ -160,6 +161,7 @@ def test_get_info_success_version(capture_logs):
     assert "test_input" in capture_logs.text
     assert "test_output" in capture_logs.text
     assert "Min Quota Consumed  500 units" in capture_logs.text
+    assert "Max Quota Consumed  5000 units" in capture_logs.text
     assert "test input description" in capture_logs.text
     assert "test output description" in capture_logs.text
 
@@ -191,7 +193,7 @@ def test_get_info_optional_inputs_displayed_correctly(capture_logs):
         default_quota=1000,
         min_quota_consumed=500,
         quota_units="units",
-        max_quota_consumed=5000
+        max_quota_consumed=5000,
     )
     test_pipeline = PipelineWithDetails(
         pipeline_name=test_pipeline_name,


### PR DESCRIPTION
### Description 

New output:

```
$ terralab pipelines details array_imputation
Pipeline Name                array_imputation
Version                      2
Description                  Impute genotypes using Beagle with the All of Us + AnVIL
                             reference panel of 515,579 samples.
Min Quota Consumed           500 samples
Max Samples Allowed Per Job  10000 samples

         Name                            Type    Description
Inputs
         multiSampleVcf                  file    A bgzipped, multi-sample VCF containing array data from one
                                                 or more chromosomes to be imputed
         outputBasename                  string  The prefix for all of the outputs' filenames. May only
                                                 contain alphanumeric characters, dashes, and underscores
         minDr2ForInclusion              float   (optional) The minimum imputation quality (DR2) for
                                                 inclusion in output VCF. Value must be between 0 and 1
                                                 (inclusive). Default is 0.0
Outputs
         imputedMultiSampleVcf           file    A multi-sample VCF file containing imputed variant genotypes
                                                 for all samples
         imputedMultiSampleVcfIndex      file    An index file for the imputed multi-sample VCF file
         chunksInfo                      file    A TSV file containing QC information about the chunks used
                                                 during imputation
         contigsInfo                     file    A TSV file containing metrics information about the input
                                                 contigs (chromosomes)
         imputedHomRefSitesOnlyVcf       file    A sites only VCF file containing information about
                                                 homozygous reference sites
         imputedHomRefSitesOnlyVcfIndex  file    An index file for the imputed homozygous reference sites
                                                 only VCF file

Example usage       terralab submit array_imputation --multiSampleVcf YOUR_VALUE_HERE --outputBasename YOUR_VALUE_HERE --description 'YOUR JOB DESCRIPTION HERE' --agreeToTerms

```



### Jira Ticket

https://broadworkbench.atlassian.net/browse/TSPS-974

### Checklist (provide links to changes)

- [ ] Test that auth flow still works, since this isn't covered by tests
    1. Main flow: run `terralab logout` and then `terralab pipelines list` - should prompt a browser login
    2. Refresh token flow: run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
    3. Auth code flow: run `terralab logout` and then `terralab login` - should prompt a browser login, and copy-paste to CLI should work without an error
    4. Auth code refresh token flow: after step 3, run `rm ~/.terralab/access_token` and then `terralab pipelines list` - should succeed without a browser login
- [ ] Updated external documentation (if applicable)
- [ ] Updated internal documentation (if applicable)
- [ ] Planned non patch version bump (if applicable)
- [ ] Updated Teaspoons PR (if applicable)
- [ ] Updated CHANGELOG.md
